### PR TITLE
Add centralized error handling middleware

### DIFF
--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,4 +1,8 @@
-require('dotenv').config();
+try {
+    require('dotenv').config();
+} catch (error) {
+    console.warn('⚠️ dotenv no encontrado, usando configuración por defecto');
+}
 
 const config = {
     // Configuración del servidor

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,61 @@
+const { errorLogger } = require('./logger');
+
+class AppError extends Error {
+    constructor(message, statusCode = 500, code = 'INTERNAL_SERVER_ERROR', details = null) {
+        super(message);
+        this.name = 'AppError';
+        this.statusCode = statusCode;
+        this.code = code;
+        this.details = details;
+        this.isOperational = true;
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+    }
+}
+
+const asyncHandler = (fn) => (req, res, next) =>
+    Promise.resolve(fn(req, res, next)).catch(next);
+
+const globalErrorHandler = (err, req, res, next) => { // eslint-disable-line no-unused-vars
+    if (res.headersSent) {
+        return next(err);
+    }
+
+    const statusCode = err.statusCode || 500;
+    const errorCode = err.code || 'INTERNAL_SERVER_ERROR';
+    const isOperational = err instanceof AppError || err.isOperational;
+
+    errorLogger(err, req, {
+        code: errorCode,
+        statusCode,
+        isOperational,
+        details: err.details
+    });
+
+    const response = {
+        success: false,
+        error: err.message || 'Error interno del servidor',
+        code: errorCode,
+        timestamp: new Date().toISOString(),
+        path: req.originalUrl,
+        method: req.method
+    };
+
+    if (err.details) {
+        response.details = err.details;
+    }
+
+    if (process.env.NODE_ENV === 'development' && err.stack) {
+        response.stack = err.stack;
+    }
+
+    res.status(statusCode).json(response);
+};
+
+module.exports = {
+    AppError,
+    asyncHandler,
+    globalErrorHandler
+};

--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -1,0 +1,5 @@
+/**
+ * Alias temporal para mantener compatibilidad con el middleware existente
+ * mientras se corrige la denominación original.
+ */
+module.exports = require('./secutity');

--- a/src/models/Student.js
+++ b/src/models/Student.js
@@ -1,0 +1,5 @@
+/**
+ * Alias temporal para mantener compatibilidad con el servicio que importa
+ * el modelo en singular.
+ */
+module.exports = require('./Students');

--- a/src/services/studentService.js
+++ b/src/services/studentService.js
@@ -1,0 +1,5 @@
+/**
+ * Alias temporal para mantener compatibilidad con los imports en camelCase
+ * mientras se corrige el nombre del archivo original.
+ */
+module.exports = require('./studenService');


### PR DESCRIPTION
## Summary
- add a reusable AppError class, async handler helper, and global error middleware that emits structured JSON responses
- add lightweight compatibility shims for the security middleware plus student model and service imports
- make the server configuration resilient when dotenv is not installed so the app can boot with defaults

## Testing
- npm run start *(fails: existing code is missing ../middleware/validation)*

------
https://chatgpt.com/codex/tasks/task_e_68de9a7938848323b771b7a2efeba106