### PR TITLE
Update admin login fetch to new auth endpoint

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -194,22 +194,23 @@ async function handleLogin(e) {
     }
     
     try {
-        const response = await fetch('/api/admin/login', {
+        const response = await fetch('/api/auth/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ username, password })
         });
-        
+
         const data = await response.json();
-        
-        if (response.ok) {
-            authToken = data.token;
+
+        if (response.ok && data.success && data.data?.token) {
+            authToken = data.data.token;
             localStorage.setItem('adminToken', authToken);
             showAdminSection();
             await loadDashboard();
             updateSystemInfo();
         } else {
-            showMessage('loginMessage', data.error || 'Error de autenticación', 'error');
+            const errorMessage = data.error || data.message || 'Error de autenticación';
+            showMessage('loginMessage', errorMessage, 'error');
         }
     } catch (error) {
         console.error('❌ Error de conexión:', error);

--- a/public/js/admin-handlers.js
+++ b/public/js/admin-handlers.js
@@ -18,22 +18,23 @@ async function handleLogin(e) {
     }
     
     try {
-        const response = await fetch('/api/admin/login', {
+        const response = await fetch('/api/auth/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ username, password })
         });
-        
+
         const data = await response.json();
-        
-        if (response.ok) {
-            authToken = data.token;
+
+        if (response.ok && data.success && data.data?.token) {
+            authToken = data.data.token;
             localStorage.setItem('adminToken', authToken);
             showAdminSection();
             await loadDashboard();
             updateSystemInfo();
         } else {
-            showMessage('loginMessage', data.error || 'Error de autenticación', 'error');
+            const errorMessage = data.error || data.message || 'Error de autenticación';
+            showMessage('loginMessage', errorMessage, 'error');
         }
     } catch (error) {
         console.error('❌ Error de conexión:', error);


### PR DESCRIPTION
## Summary
- update the admin panel login flow to call the new `/api/auth/login` endpoint
- adjust login response handling to read the token from the new payload structure and show backend-provided messages

## Testing
- npm start
- curl -s -X POST http://localhost:3000/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"admin123"}' | jq

------
https://chatgpt.com/codex/tasks/task_e_68ded67c1450832383985803807edd7b