### PR TITLE
Add admin configuration, key, and device management endpoints

### DIFF
--- a/data/admin_keys.csv
+++ b/data/admin_keys.csv
@@ -1,0 +1,1 @@
+key,description,is_active,created_at,deactivated_at

--- a/data/devices.csv
+++ b/data/devices.csv
@@ -1,0 +1,2 @@
+device_fingerprint,matricula,first_registration,last_used,user_agent
+

--- a/data/system_config.csv
+++ b/data/system_config.csv
@@ -1,0 +1,8 @@
+key,value,updated_at
+location_restriction_enabled,false,2025-10-02T00:00:00.000Z
+device_restriction_enabled,false,2025-10-02T00:00:00.000Z
+admin_key_bypass_enabled,false,2025-10-02T00:00:00.000Z
+location_name,,2025-10-02T00:00:00.000Z
+location_latitude,,2025-10-02T00:00:00.000Z
+location_longitude,,2025-10-02T00:00:00.000Z
+location_radius_km,1,2025-10-02T00:00:00.000Z

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ const { requestLogger } = require('./middleware/logger');
 const attendanceRoutes = require('./routes/attendance');
 const adminRoutes = require('./routes/admin');
 const authRoutes = require('./routes/auth');
+const configRoutes = require('./routes/config');
 
 const app = express();
 
@@ -44,6 +45,7 @@ app.get('/api/health', (req, res) => {
 });
 
 // API Routes
+app.use('/api/config', configRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/attendance', attendanceRoutes);
 app.use('/api/admin', adminRoutes);

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -18,9 +18,12 @@ const config = {
     FILES: {
         STUDENTS: 'data/students.csv',
         ATTENDANCE: 'data/attendance.csv',
-        ADMIN: 'data/admin.csv'
+        ADMIN: 'data/admin.csv',
+        CONFIG: 'data/system_config.csv',
+        ADMIN_KEYS: 'data/admin_keys.csv',
+        DEVICES: 'data/devices.csv'
     },
-    
+
     // Configuración de CSV
     CSV_HEADERS: {
         STUDENTS: [
@@ -38,7 +41,37 @@ const config = {
         ADMIN: [
             { id: 'username', title: 'username' },
             { id: 'password', title: 'password' }
+        ],
+        CONFIG: [
+            { id: 'key', title: 'key' },
+            { id: 'value', title: 'value' },
+            { id: 'updated_at', title: 'updated_at' }
+        ],
+        ADMIN_KEYS: [
+            { id: 'key', title: 'key' },
+            { id: 'description', title: 'description' },
+            { id: 'is_active', title: 'is_active' },
+            { id: 'created_at', title: 'created_at' },
+            { id: 'deactivated_at', title: 'deactivated_at' }
+        ],
+        DEVICES: [
+            { id: 'device_fingerprint', title: 'device_fingerprint' },
+            { id: 'matricula', title: 'matricula' },
+            { id: 'first_registration', title: 'first_registration' },
+            { id: 'last_used', title: 'last_used' },
+            { id: 'user_agent', title: 'user_agent' }
         ]
+    },
+
+    // Configuración del sistema (restricciones y comportamiento)
+    DEFAULT_SYSTEM_CONFIG: {
+        location_restriction_enabled: 'false',
+        device_restriction_enabled: 'false',
+        admin_key_bypass_enabled: 'false',
+        location_name: '',
+        location_latitude: '',
+        location_longitude: '',
+        location_radius_km: '1'
     },
     
     // Configuración de validación

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -2,6 +2,9 @@ const AdminService = require('../services/adminService');
 const StudentService = require('../services/studentService');
 const AttendanceService = require('../services/attendanceService');
 const SystemService = require('../services/systemService');
+const ConfigService = require('../services/configService');
+const AdminKeyService = require('../services/adminKeyService');
+const DeviceService = require('../services/deviceService');
 const { asyncHandler } = require('../middleware/errorHandler');
 
 class AdminController {
@@ -49,10 +52,11 @@ class AdminController {
         const { students } = req.body;
         
         const result = await StudentService.updateStudentsList(students);
-        
+
         // Limpiar registros de asistencia al subir nueva lista
         await AttendanceService.clearAttendanceRecords();
-        
+        await DeviceService.clearAllDevices();
+
         res.status(200).json({
             success: true,
             message: `${result.validStudents} ${result.message}. Registros de asistencia reiniciados.`,
@@ -160,14 +164,83 @@ class AdminController {
      */
     static cleanupSystem = asyncHandler(async (req, res) => {
         console.log('🧹 Petición de limpieza del sistema');
-        
+
         const cleanup = await SystemService.cleanupSystem();
-        
+
         res.status(200).json({
             success: true,
             message: 'Limpieza completada exitosamente',
             data: cleanup
         });
+    });
+
+    /**
+     * Obtener configuración del sistema (restricciones)
+     * GET /api/admin/config
+     */
+    static getSystemConfig = asyncHandler(async (req, res) => {
+        console.log('⚙️ Petición de configuración del sistema');
+
+        const systemConfig = await ConfigService.getSystemConfig();
+        res.status(200).json(systemConfig);
+    });
+
+    /**
+     * Actualizar configuración del sistema (restricciones)
+     * POST /api/admin/config
+     */
+    static updateSystemConfig = asyncHandler(async (req, res) => {
+        console.log('💾 Petición de guardado de configuración');
+
+        const updatedConfig = await ConfigService.saveSystemConfig(req.body || {});
+        res.status(200).json(updatedConfig);
+    });
+
+    /**
+     * Obtener claves administrativas
+     * GET /api/admin/admin-keys
+     */
+    static getAdminKeys = asyncHandler(async (req, res) => {
+        console.log('🔑 Petición de listado de claves administrativas');
+
+        const keys = await AdminKeyService.getAllKeys();
+        res.status(200).json(keys);
+    });
+
+    /**
+     * Crear nueva clave administrativa
+     * POST /api/admin/admin-keys
+     */
+    static createAdminKey = asyncHandler(async (req, res) => {
+        console.log('➕ Petición de creación de clave administrativa');
+
+        const { key, description } = req.body || {};
+        const newKey = await AdminKeyService.createKey(key, description);
+
+        res.status(201).json(newKey);
+    });
+
+    /**
+     * Desactivar clave administrativa
+     * DELETE /api/admin/admin-keys/:key
+     */
+    static deactivateAdminKey = asyncHandler(async (req, res) => {
+        const { key } = req.params;
+        console.log(`🗝️ Petición de desactivación de clave: ${key}`);
+
+        const updatedKey = await AdminKeyService.deactivateKey(key);
+        res.status(200).json(updatedKey);
+    });
+
+    /**
+     * Obtener dispositivos registrados
+     * GET /api/admin/devices
+     */
+    static getRegisteredDevices = asyncHandler(async (req, res) => {
+        console.log('📱 Petición de dispositivos registrados');
+
+        const devices = await DeviceService.getAllDevices();
+        res.status(200).json(devices);
     });
 
     /**

--- a/src/controllers/attendanceController.js
+++ b/src/controllers/attendanceController.js
@@ -9,9 +9,13 @@ class AttendanceController {
     static registerAttendance = asyncHandler(async (req, res) => {
         console.log('📝 Petición de registro de asistencia recibida');
         
-        const { matricula } = req.body;
-        
-        const result = await AttendanceService.registerAttendance(matricula);
+        const { matricula, deviceFingerprint } = req.body;
+
+        const result = await AttendanceService.registerAttendance({
+            matricula,
+            deviceFingerprint,
+            userAgent: req.headers['user-agent'] || ''
+        });
         
         res.status(200).json({
             success: true,

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -17,6 +17,28 @@ router.use(sanitizeInput);
  * Rutas principales de estadísticas y reportes
  */
 
+/**
+ * Configuración del sistema y restricciones
+ */
+router.get('/config', AdminController.getSystemConfig);
+router.post('/config', AdminController.updateSystemConfig);
+
+/**
+ * Gestión de claves administrativas
+ */
+router.get('/admin-keys', AdminController.getAdminKeys);
+router.post('/admin-keys', AdminController.createAdminKey);
+router.delete('/admin-keys/:key', AdminController.deactivateAdminKey);
+
+/**
+ * Gestión de dispositivos registrados
+ */
+router.get('/devices', AdminController.getRegisteredDevices);
+
+/**
+ * Rutas principales de estadísticas y reportes
+ */
+
 // Obtener estadísticas generales del sistema
 router.get('/stats', AdminController.getSystemStats);
 

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const ConfigService = require('../services/configService');
+const { asyncHandler } = require('../middleware/errorHandler');
+
+const router = express.Router();
+
+// Obtener configuración pública del sistema (para clientes)
+router.get('/', asyncHandler(async (req, res) => {
+    const systemConfig = await ConfigService.getPublicConfig();
+    res.status(200).json(systemConfig);
+}));
+
+module.exports = router;
+

--- a/src/services/adminKeyService.js
+++ b/src/services/adminKeyService.js
@@ -1,0 +1,155 @@
+const CSVService = require('./csvService');
+const config = require('../config/server');
+const { AppError } = require('../middleware/errorHandler');
+
+class AdminKeyService {
+    /**
+     * Asegurar que el archivo de claves exista y tenga el formato correcto
+     */
+    static async ensureInitialized() {
+        try {
+            const exists = await CSVService.fileExists(config.FILES.ADMIN_KEYS);
+
+            if (!exists) {
+                await CSVService.writeEmptyCSV(config.FILES.ADMIN_KEYS, config.CSV_HEADERS.ADMIN_KEYS);
+                return;
+            }
+
+            const keys = await CSVService.readCSV(config.FILES.ADMIN_KEYS);
+            await CSVService.writeCSV(config.FILES.ADMIN_KEYS, keys, config.CSV_HEADERS.ADMIN_KEYS);
+        } catch (error) {
+            console.error('❌ Error asegurando archivo de claves administrativas:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo inicializar las claves administrativas', 500, 'ADMIN_KEYS_INIT_ERROR');
+        }
+    }
+
+    /**
+     * Obtener todas las claves administrativas
+     */
+    static async getAllKeys() {
+        try {
+            await this.ensureInitialized();
+
+            const records = await CSVService.readCSV(config.FILES.ADMIN_KEYS);
+            return records.map(record => ({
+                key: (record.key || '').trim().toUpperCase(),
+                description: (record.description || '').trim(),
+                is_active: record.is_active === 'false' ? 'false' : 'true',
+                created_at: record.created_at || '',
+                deactivated_at: record.deactivated_at || ''
+            }));
+        } catch (error) {
+            console.error('❌ Error obteniendo claves administrativas:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudieron obtener las claves administrativas', 500, 'ADMIN_KEYS_LOAD_ERROR');
+        }
+    }
+
+    /**
+     * Crear una nueva clave administrativa
+     */
+    static async createKey(key, description) {
+        try {
+            const normalizedKey = this.normalizeKey(key);
+            const cleanDescription = (description || '').toString().trim();
+
+            if (!normalizedKey) {
+                throw new AppError('La clave es requerida', 400, 'ADMIN_KEY_REQUIRED');
+            }
+
+            if (normalizedKey.length < 4) {
+                throw new AppError('La clave debe tener al menos 4 caracteres', 400, 'ADMIN_KEY_TOO_SHORT');
+            }
+
+            if (!cleanDescription) {
+                throw new AppError('La descripción es requerida', 400, 'ADMIN_KEY_DESCRIPTION_REQUIRED');
+            }
+
+            const existingKeys = await this.getAllKeys();
+            if (existingKeys.some(record => record.key === normalizedKey && record.is_active === 'true')) {
+                throw new AppError('Ya existe una clave activa con ese nombre', 409, 'ADMIN_KEY_DUPLICATED');
+            }
+
+            const timestamp = new Date().toISOString();
+            const newKey = {
+                key: normalizedKey,
+                description: cleanDescription,
+                is_active: 'true',
+                created_at: timestamp,
+                deactivated_at: ''
+            };
+
+            await CSVService.appendToCSV(config.FILES.ADMIN_KEYS, newKey, config.CSV_HEADERS.ADMIN_KEYS);
+
+            console.log(`🔑 Nueva clave administrativa creada: ${normalizedKey}`);
+            return newKey;
+        } catch (error) {
+            console.error('❌ Error creando clave administrativa:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo crear la clave administrativa', 500, 'ADMIN_KEY_CREATE_ERROR');
+        }
+    }
+
+    /**
+     * Desactivar una clave administrativa existente
+     */
+    static async deactivateKey(key) {
+        try {
+            const normalizedKey = this.normalizeKey(key);
+
+            if (!normalizedKey) {
+                throw new AppError('La clave es requerida', 400, 'ADMIN_KEY_REQUIRED');
+            }
+
+            const keys = await this.getAllKeys();
+            const existing = keys.find(record => record.key === normalizedKey);
+
+            if (!existing) {
+                throw new AppError('Clave administrativa no encontrada', 404, 'ADMIN_KEY_NOT_FOUND');
+            }
+
+            if (existing.is_active === 'false') {
+                return existing;
+            }
+
+            const updatedKey = {
+                ...existing,
+                is_active: 'false',
+                deactivated_at: new Date().toISOString()
+            };
+
+            const updated = await CSVService.updateInCSV(
+                config.FILES.ADMIN_KEYS,
+                { key: normalizedKey },
+                updatedKey,
+                config.CSV_HEADERS.ADMIN_KEYS
+            );
+
+            if (!updated) {
+                throw new AppError('No se pudo desactivar la clave administrativa', 500, 'ADMIN_KEY_DEACTIVATE_ERROR');
+            }
+
+            console.log(`🗝️ Clave administrativa desactivada: ${normalizedKey}`);
+            return updatedKey;
+        } catch (error) {
+            console.error('❌ Error desactivando clave administrativa:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo desactivar la clave administrativa', 500, 'ADMIN_KEY_DEACTIVATE_ERROR');
+        }
+    }
+
+    /**
+     * Eliminar todas las claves (utilizado en pruebas o reinicios)
+     */
+    static async clearAll() {
+        await CSVService.writeEmptyCSV(config.FILES.ADMIN_KEYS, config.CSV_HEADERS.ADMIN_KEYS);
+    }
+
+    /**
+     * Normalizar formato de clave
+     */
+    static normalizeKey(key) {
+        if (!key) return '';
+        return key.toString().trim().toUpperCase();
+    }
+}
+
+module.exports = AdminKeyService;
+

--- a/src/services/configService.js
+++ b/src/services/configService.js
@@ -1,0 +1,168 @@
+const CSVService = require('./csvService');
+const config = require('../config/server');
+const { AppError } = require('../middleware/errorHandler');
+
+class ConfigService {
+    /**
+     * Asegurar que el archivo de configuración exista con formato correcto
+     */
+    static async ensureInitialized() {
+        try {
+            const exists = await CSVService.fileExists(config.FILES.CONFIG);
+
+            if (!exists) {
+                await this.saveSystemConfig(config.DEFAULT_SYSTEM_CONFIG);
+                return;
+            }
+
+            // Reescribir para asegurar estructura y valores por defecto
+            const currentConfig = await this.getSystemConfig();
+            await this.saveSystemConfig(currentConfig);
+        } catch (error) {
+            console.error('❌ Error asegurando archivo de configuración:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo inicializar la configuración', 500, 'CONFIG_INIT_ERROR');
+        }
+    }
+
+    /**
+     * Obtener configuración del sistema (valores en texto)
+     */
+    static async getSystemConfig() {
+        try {
+            await this.ensureFile();
+
+            const rows = await CSVService.readCSV(config.FILES.CONFIG);
+            const baseConfig = { ...config.DEFAULT_SYSTEM_CONFIG };
+            let updatedAt = null;
+
+            rows.forEach(row => {
+                if (!row.key) return;
+
+                const key = row.key.trim();
+                const value = row.value ?? '';
+
+                if (Object.prototype.hasOwnProperty.call(baseConfig, key)) {
+                    baseConfig[key] = value;
+                } else {
+                    baseConfig[key] = value;
+                }
+
+                if (row.updated_at) {
+                    if (!updatedAt || new Date(row.updated_at) > new Date(updatedAt)) {
+                        updatedAt = row.updated_at;
+                    }
+                }
+            });
+
+            if (updatedAt) {
+                baseConfig.updated_at = updatedAt;
+            }
+
+            return baseConfig;
+        } catch (error) {
+            console.error('❌ Error obteniendo configuración del sistema:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo obtener la configuración del sistema', 500, 'CONFIG_LOAD_ERROR');
+        }
+    }
+
+    /**
+     * Guardar configuración del sistema
+     */
+    static async saveSystemConfig(newConfig = {}) {
+        try {
+            await this.ensureFile();
+
+            const sanitizedConfig = { ...config.DEFAULT_SYSTEM_CONFIG };
+            const allowedKeys = new Set(Object.keys(config.DEFAULT_SYSTEM_CONFIG));
+
+            Object.entries(newConfig || {}).forEach(([key, value]) => {
+                if (typeof value === 'undefined' || value === null) {
+                    return;
+                }
+
+                const cleanKey = key.toString().trim();
+                if (!allowedKeys.has(cleanKey)) {
+                    return;
+                }
+
+                const cleanValue = value.toString().trim();
+                sanitizedConfig[cleanKey] = cleanValue;
+            });
+
+            sanitizedConfig.location_restriction_enabled = this.normalizeBoolean(sanitizedConfig.location_restriction_enabled);
+            sanitizedConfig.device_restriction_enabled = this.normalizeBoolean(sanitizedConfig.device_restriction_enabled);
+            sanitizedConfig.admin_key_bypass_enabled = this.normalizeBoolean(sanitizedConfig.admin_key_bypass_enabled);
+
+            const radius = parseFloat(sanitizedConfig.location_radius_km);
+            if (Number.isNaN(radius) || radius <= 0) {
+                sanitizedConfig.location_radius_km = config.DEFAULT_SYSTEM_CONFIG.location_radius_km;
+            } else {
+                sanitizedConfig.location_radius_km = radius.toString();
+            }
+
+            const timestamp = new Date().toISOString();
+            const records = Object.entries(sanitizedConfig).map(([key, value]) => ({
+                key,
+                value: value == null ? '' : value.toString(),
+                updated_at: timestamp
+            }));
+
+            await CSVService.writeCSV(config.FILES.CONFIG, records, config.CSV_HEADERS.CONFIG);
+
+            return { ...sanitizedConfig, updated_at: timestamp };
+        } catch (error) {
+            console.error('❌ Error guardando configuración del sistema:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo guardar la configuración del sistema', 500, 'CONFIG_SAVE_ERROR');
+        }
+    }
+
+    /**
+     * Obtener configuración formateada para consumo público (valores booleanos)
+     */
+    static async getPublicConfig() {
+        const configData = await this.getSystemConfig();
+
+        return {
+            location_restriction_enabled: configData.location_restriction_enabled === 'true',
+            device_restriction_enabled: configData.device_restriction_enabled === 'true',
+            admin_key_bypass_enabled: configData.admin_key_bypass_enabled === 'true',
+            location_name: configData.location_name || '',
+            location_latitude: configData.location_latitude || '',
+            location_longitude: configData.location_longitude || '',
+            location_radius_km: configData.location_radius_km || config.DEFAULT_SYSTEM_CONFIG.location_radius_km,
+            updated_at: configData.updated_at || new Date().toISOString()
+        };
+    }
+
+    /**
+     * Normalizar valores booleanos a texto
+     */
+    static normalizeBoolean(value) {
+        if (typeof value === 'boolean') {
+            return value ? 'true' : 'false';
+        }
+
+        const normalized = value ? value.toString().trim().toLowerCase() : 'false';
+        return ['true', '1', 'yes', 'on'].includes(normalized) ? 'true' : 'false';
+    }
+
+    /**
+     * Asegurar que el archivo existe (sin sobrescribir datos)
+     */
+    static async ensureFile() {
+        const exists = await CSVService.fileExists(config.FILES.CONFIG);
+
+        if (!exists) {
+            const timestamp = new Date().toISOString();
+            const records = Object.entries(config.DEFAULT_SYSTEM_CONFIG).map(([key, value]) => ({
+                key,
+                value,
+                updated_at: timestamp
+            }));
+
+            await CSVService.writeCSV(config.FILES.CONFIG, records, config.CSV_HEADERS.CONFIG);
+        }
+    }
+}
+
+module.exports = ConfigService;

--- a/src/services/deviceService.js
+++ b/src/services/deviceService.js
@@ -1,0 +1,116 @@
+const CSVService = require('./csvService');
+const config = require('../config/server');
+const { AppError } = require('../middleware/errorHandler');
+
+class DeviceService {
+    /**
+     * Asegurar que el archivo de dispositivos exista
+     */
+    static async ensureInitialized() {
+        try {
+            const exists = await CSVService.fileExists(config.FILES.DEVICES);
+
+            if (!exists) {
+                await CSVService.writeEmptyCSV(config.FILES.DEVICES, config.CSV_HEADERS.DEVICES);
+                return;
+            }
+
+            const records = await CSVService.readCSV(config.FILES.DEVICES);
+            await CSVService.writeCSV(config.FILES.DEVICES, records, config.CSV_HEADERS.DEVICES);
+        } catch (error) {
+            console.error('❌ Error asegurando archivo de dispositivos:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo inicializar el registro de dispositivos', 500, 'DEVICES_INIT_ERROR');
+        }
+    }
+
+    /**
+     * Obtener todos los dispositivos registrados
+     */
+    static async getAllDevices() {
+        try {
+            await this.ensureInitialized();
+
+            const records = await CSVService.readCSV(config.FILES.DEVICES);
+            const devices = records.map(record => ({
+                device_fingerprint: (record.device_fingerprint || '').trim(),
+                matricula: (record.matricula || '').trim().toUpperCase(),
+                first_registration: record.first_registration || '',
+                last_used: record.last_used || record.first_registration || '',
+                user_agent: record.user_agent || ''
+            }));
+
+            return devices.sort((a, b) => {
+                const dateA = a.last_used ? new Date(a.last_used).getTime() : 0;
+                const dateB = b.last_used ? new Date(b.last_used).getTime() : 0;
+                return dateB - dateA;
+            });
+        } catch (error) {
+            console.error('❌ Error obteniendo dispositivos registrados:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudieron obtener los dispositivos registrados', 500, 'DEVICES_LOAD_ERROR');
+        }
+    }
+
+    /**
+     * Registrar o actualizar el uso de un dispositivo
+     */
+    static async registerDeviceUsage({ matricula, deviceFingerprint, userAgent }) {
+        try {
+            await this.ensureInitialized();
+
+            const fingerprint = (deviceFingerprint || '').toString().trim();
+            if (!fingerprint) {
+                return null;
+            }
+
+            const normalizedMatricula = (matricula || '').toString().trim().toUpperCase();
+            const userAgentValue = (userAgent || '').toString().trim();
+            const timestamp = new Date().toISOString();
+
+            const existingDevices = await CSVService.readCSV(config.FILES.DEVICES);
+            const existingDevice = existingDevices.find(device => device.device_fingerprint === fingerprint);
+
+            if (existingDevice) {
+                const updatedDevice = {
+                    device_fingerprint: fingerprint,
+                    matricula: normalizedMatricula || (existingDevice.matricula || ''),
+                    first_registration: existingDevice.first_registration || timestamp,
+                    last_used: timestamp,
+                    user_agent: userAgentValue || existingDevice.user_agent || ''
+                };
+
+                await CSVService.updateInCSV(
+                    config.FILES.DEVICES,
+                    { device_fingerprint: fingerprint },
+                    updatedDevice,
+                    config.CSV_HEADERS.DEVICES
+                );
+
+                return updatedDevice;
+            }
+
+            const newDevice = {
+                device_fingerprint: fingerprint,
+                matricula: normalizedMatricula,
+                first_registration: timestamp,
+                last_used: timestamp,
+                user_agent: userAgentValue
+            };
+
+            await CSVService.appendToCSV(config.FILES.DEVICES, newDevice, config.CSV_HEADERS.DEVICES);
+            return newDevice;
+        } catch (error) {
+            console.error('❌ Error registrando dispositivo:', error);
+            throw error instanceof AppError ? error : new AppError('No se pudo registrar el dispositivo', 500, 'DEVICE_REGISTER_ERROR');
+        }
+    }
+
+    /**
+     * Limpiar el registro de dispositivos
+     */
+    static async clearAllDevices() {
+        await CSVService.writeEmptyCSV(config.FILES.DEVICES, config.CSV_HEADERS.DEVICES);
+    }
+}
+
+module.exports = DeviceService;
+


### PR DESCRIPTION
## Summary
- add persistent CSV-backed storage for system configuration, administrative keys, and device registrations
- expose new admin API endpoints for managing restrictions, admin keys, and registered devices plus a public configuration route
- record device usage during attendance, clear device registry with new rosters, and include the new data files in system status/backup flows

## Testing
- npm test *(fails: jest not found)*
- curl http://localhost:3000/api/config
- curl -X POST http://localhost:3000/api/admin/config -H "Authorization: Bearer <token>" -d '{"location_restriction_enabled":"true"}'
- curl -X POST http://localhost:3000/api/admin/admin-keys -H "Authorization: Bearer <token>" -d '{"key":"SUPERVISOR2024","description":"Clave de prueba"}'
- curl -X DELETE http://localhost:3000/api/admin/admin-keys/SUPERVISOR2024 -H "Authorization: Bearer <token>"
- curl -X POST http://localhost:3000/api/attendance -d '{"matricula":"B6759495","deviceFingerprint":"abc123"}'
- curl http://localhost:3000/api/admin/devices -H "Authorization: Bearer <token>"


------
https://chatgpt.com/codex/tasks/task_e_68ded742d9fc83238ed0a2eb353c66fc