### PR TITLE
Refactor admin dashboard layout and scripts

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,4 +1,172 @@
-<p style="color: #666;">Permite que supervisores con claves especiales puedan saltarse las restricciones de ubicación y dispositivo.</p>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Panel de Administración - Pase de Lista</title>
+    <link rel="stylesheet" href="css/admin-styles.css">
+    <script defer src="js/admin-utils.js"></script>
+    <script defer src="js/admin-data.js"></script>
+    <script defer src="js/admin-handlers.js"></script>
+    <script defer src="js/admin-app.js"></script>
+</head>
+<body>
+    <!-- Login Form -->
+    <div id="loginSection" class="login-container">
+        <div style="text-align: center; margin-bottom: 30px;">
+            <div style="width: 60px; height: 60px; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 50%; margin: 0 auto 15px; display: flex; align-items: center; justify-content: center; font-size: 24px; color: white;">👤</div>
+            <h2>Acceso Administrativo</h2>
+        </div>
+
+        <form id="loginForm">
+            <div class="form-group">
+                <label for="username">Usuario:</label>
+                <input type="text" id="username" name="username" autocomplete="username" required>
+            </div>
+
+            <div class="form-group">
+                <label for="password">Contraseña:</label>
+                <input type="password" id="password" name="password" autocomplete="current-password" required>
+            </div>
+
+            <button type="submit" class="btn" style="width: 100%;">Iniciar Sesión</button>
+        </form>
+
+        <div class="message" id="loginMessage"></div>
+
+        <div style="text-align: center; margin-top: 20px;">
+            <a href="/" class="back-link" style="color: #6866ea;">← Volver al pase de lista</a>
+        </div>
+    </div>
+
+    <!-- Admin Dashboard -->
+    <div id="adminSection" class="hidden">
+        <div class="header">
+            <div class="container">
+                <h1>📊 Panel de Administración</h1>
+                <div>
+                    <a href="/" class="back-link">← Pase de Lista</a>
+                    <button class="logout-btn" onclick="logout()">Cerrar Sesión</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="main-container">
+            <!-- Estadísticas -->
+            <div class="stats-grid">
+                <div class="stat-card total">
+                    <span class="stat-number" id="totalStudents">-</span>
+                    <span class="stat-label">Total Personal</span>
+                </div>
+                <div class="stat-card present">
+                    <span class="stat-number" id="presentRegistered">-</span>
+                    <span class="stat-label">Presentes (En Lista)</span>
+                </div>
+                <div class="stat-card present">
+                    <span class="stat-number" id="attendanceRate">-</span>
+                    <span class="stat-label">% Asistencia</span>
+                </div>
+                <div class="stat-card absent">
+                    <span class="stat-number" id="absent">-</span>
+                    <span class="stat-label">Faltistas</span>
+                </div>
+            </div>
+
+            <!-- Tabs -->
+            <div class="tabs">
+                <div class="tab active" data-tab="overview">📈 Resumen</div>
+                <div class="tab" data-tab="detailed">📋 Lista Detallada</div>
+                <div class="tab" data-tab="restrictions">🛡️ Restricciones</div>
+                <div class="tab" data-tab="upload">📤 Subir Lista</div>
+                <div class="tab" data-tab="devices">📱 Dispositivos</div>
+                <div class="tab" data-tab="settings">⚙️ Configuración</div>
+            </div>
+
+            <!-- Tab: Overview -->
+            <div id="overviewTab">
+                <div class="card">
+                    <h2>📅 Resumen del Día</h2>
+                    <div id="overviewContent">
+                        <div class="loading" id="overviewLoading">
+                            <div class="spinner"></div>
+                            <p>Cargando estadísticas...</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Tab: Detailed List -->
+            <div id="detailedTab" class="hidden">
+                <div class="card">
+                    <h2>📋 Lista Detallada de Asistencia</h2>
+                    <div class="loading" id="detailedLoading">
+                        <div class="spinner"></div>
+                        <p>Cargando lista detallada...</p>
+                    </div>
+                    <div id="detailedContent"></div>
+                </div>
+            </div>
+
+            <!-- Tab: Restrictions Configuration -->
+            <div id="restrictionsTab" class="hidden">
+                <div class="card">
+                    <h2>🛡️ Configuración de Restricciones</h2>
+
+                    <div class="info-box">
+                        <h4>ℹ️ Información sobre las Restricciones</h4>
+                        <p>Las restricciones permiten controlar dónde y cómo se puede registrar la asistencia. Los supervisores con claves administrativas pueden saltarse estas restricciones.</p>
+                    </div>
+
+                    <form id="restrictionsForm">
+                        <!-- Restricción de Ubicación -->
+                        <div class="restriction-card location">
+                            <div class="checkbox-group">
+                                <input type="checkbox" id="locationRestrictionEnabled" name="location_restriction_enabled">
+                                <label for="locationRestrictionEnabled"><strong>📍 Restricción por Ubicación</strong></label>
+                            </div>
+                            <p style="margin-bottom: 15px; color: #666;">Solo permite registrar asistencia dentro de un radio específico de una ubicación.</p>
+
+                            <div id="locationSettings">
+                                <div class="form-row">
+                                    <div class="form-group">
+                                        <label for="locationName">Nombre del Lugar:</label>
+                                        <input type="text" id="locationName" name="location_name" placeholder="Ej: Escuela Superior de Guerra">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="locationRadius">Radio (km):</label>
+                                        <input type="number" id="locationRadius" name="location_radius_km" min="0.1" max="10" step="0.1" placeholder="1.0">
+                                    </div>
+                                </div>
+                                <div class="form-row">
+                                    <div class="form-group">
+                                        <label for="locationLatitude">Latitud:</label>
+                                        <input type="text" id="locationLatitude" name="location_latitude" placeholder="19.4326">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="locationLongitude">Longitud:</label>
+                                        <input type="text" id="locationLongitude" name="location_longitude" placeholder="-99.1332">
+                                    </div>
+                                </div>
+                                <button type="button" class="btn btn-secondary btn-small" onclick="getCurrentLocation()">📍 Obtener mi Ubicación Actual</button>
+                            </div>
+                        </div>
+
+                        <!-- Restricción de Dispositivo -->
+                        <div class="restriction-card device">
+                            <div class="checkbox-group">
+                                <input type="checkbox" id="deviceRestrictionEnabled" name="device_restriction_enabled">
+                                <label for="deviceRestrictionEnabled"><strong>📱 Restricción por Dispositivo</strong></label>
+                            </div>
+                            <p style="color: #666;">Solo permite un registro por dispositivo/teléfono. Evita que múltiples personas usen el mismo dispositivo.</p>
+                        </div>
+
+                        <!-- Claves Administrativas -->
+                        <div class="restriction-card admin-keys">
+                            <div class="checkbox-group">
+                                <input type="checkbox" id="adminKeyBypassEnabled" name="admin_key_bypass_enabled">
+                                <label for="adminKeyBypassEnabled"><strong>🔑 Permitir Claves de Supervisor</strong></label>
+                            </div>
+                            <p style="color: #666;">Permite que supervisores con claves especiales puedan saltarse las restricciones de ubicación y dispositivo.</p>
                         </div>
 
                         <button type="submit" class="btn" id="saveRestrictionsBtn">Guardar Configuración</button>
@@ -63,18 +231,18 @@
                             <strong>Obligatorios:</strong> matricula, nombre, grupo
                         </p>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="csvFile">Seleccionar archivo CSV:</label>
                         <input type="file" id="csvFile" accept=".csv" onchange="previewCSV()">
                     </div>
-                    
+
                     <div id="csvPreview"></div>
-                    
+
                     <button class="btn" onclick="uploadStudents()" id="uploadBtn" disabled>
                         Subir Lista de Personal
                     </button>
-                    
+
                     <div class="message" id="uploadMessage"></div>
                 </div>
             </div>
@@ -86,12 +254,12 @@
                     <p style="margin-bottom: 20px; color: #666;">
                         Lista de dispositivos que han registrado asistencia. Útil para monitorear el uso del sistema.
                     </p>
-                    
+
                     <div class="loading" id="devicesLoading">
                         <div class="spinner"></div>
                         <p>Cargando dispositivos...</p>
                     </div>
-                    
+
                     <div id="devicesContent"></div>
                 </div>
             </div>
@@ -100,7 +268,7 @@
             <div id="settingsTab" class="hidden">
                 <div class="card">
                     <h2>⚙️ Configuración del Sistema</h2>
-                    
+
                     <!-- Cambiar Contraseña -->
                     <div style="margin-bottom: 30px;">
                         <h3 style="color: #333; margin-bottom: 15px;">🔐 Cambiar Contraseña</h3>
@@ -110,26 +278,26 @@
                                 <label for="currentPassword">Contraseña Actual:</label>
                                 <input type="password" id="currentPassword" name="currentPassword" autocomplete="current-password" required>
                             </div>
-                            
+
                             <div class="form-group">
                                 <label for="newPassword">Nueva Contraseña:</label>
                                 <input type="password" id="newPassword" name="newPassword" autocomplete="new-password" minlength="6" required>
                                 <small style="color: #666; font-size: 12px;">Mínimo 6 caracteres</small>
                             </div>
-                            
+
                             <div class="form-group">
                                 <label for="confirmPassword">Confirmar Nueva Contraseña:</label>
                                 <input type="password" id="confirmPassword" name="confirmPassword" autocomplete="new-password" minlength="6" required>
                             </div>
-                            
+
                             <button type="submit" class="btn" id="changePasswordBtn">
                                 Cambiar Contraseña
                             </button>
                         </form>
-                        
+
                         <div class="message" id="passwordMessage"></div>
                     </div>
-                    
+
                     <!-- Información del Sistema -->
                     <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
                         <h3 style="color: #333; margin-bottom: 15px;">ℹ️ Información del Sistema</h3>
@@ -150,1363 +318,5 @@
             </div>
         </div>
     </div>
-
-<script>
-let authToken = localStorage.getItem('adminToken');
-let currentStudents = [];
-let systemConfig = {};
-
-// Verificar autenticación al cargar
-if (authToken) {
-    showAdminSection();
-    loadDashboard();
-}
-
-// Event Listeners
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('🔄 DOM cargado, configurando event listeners...');
-    
-    const loginForm = document.getElementById('loginForm');
-    if (loginForm) {
-        loginForm.addEventListener('submit', handleLogin);
-    }
-
-    const changePasswordForm = document.getElementById('changePasswordForm');
-    if (changePasswordForm) {
-        changePasswordForm.addEventListener('submit', handleChangePassword);
-    }
-
-    const restrictionsForm = document.getElementById('restrictionsForm');
-    if (restrictionsForm) {
-        restrictionsForm.addEventListener('submit', handleRestrictionsSubmit);
-    }
-});
-
-async function handleLogin(e) {
-    e.preventDefault();
-    
-    const username = document.getElementById('username').value;
-    const password = document.getElementById('password').value;
-    
-    if (!username || !password) {
-        showMessage('loginMessage', 'Usuario y contraseña son requeridos', 'error');
-        return;
-    }
-    
-    try {
-        const response = await fetch('/api/auth/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, password })
-        });
-
-        const data = await response.json();
-
-        if (response.ok && data.success && data.data?.token) {
-            authToken = data.data.token;
-            localStorage.setItem('adminToken', authToken);
-            showAdminSection();
-            await loadDashboard();
-            updateSystemInfo();
-        } else {
-            const errorMessage = data.error || data.message || 'Error de autenticación';
-            showMessage('loginMessage', errorMessage, 'error');
-        }
-    } catch (error) {
-        console.error('❌ Error de conexión:', error);
-        showMessage('loginMessage', 'Error de conexión: ' + error.message, 'error');
-    }
-}
-
-async function handleChangePassword(e) {
-    e.preventDefault();
-    
-    const currentPassword = document.getElementById('currentPassword').value;
-    const newPassword = document.getElementById('newPassword').value;
-    const confirmPassword = document.getElementById('confirmPassword').value;
-    
-    if (newPassword !== confirmPassword) {
-        showMessage('passwordMessage', 'Las contraseñas no coinciden', 'error');
-        return;
-    }
-    
-    if (newPassword.length < 6) {
-        showMessage('passwordMessage', 'La contraseña debe tener al menos 6 caracteres', 'error');
-        return;
-    }
-    
-    const changePasswordBtn = document.getElementById('changePasswordBtn');
-    changePasswordBtn.disabled = true;
-    changePasswordBtn.textContent = 'Cambiando...';
-    
-    try {
-        const response = await fetch('/api/admin/change-password', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${authToken}`
-            },
-            body: JSON.stringify({ currentPassword, newPassword })
-        });
-        
-        const data = await response.json();
-        
-        if (response.ok) {
-            showMessage('passwordMessage', 'Contraseña cambiada exitosamente', 'success');
-            document.getElementById('changePasswordForm').reset();
-            
-            setTimeout(() => {
-                if (confirm('Contraseña cambiada exitosamente. ¿Deseas cerrar sesión para usar la nueva contraseña?')) {
-                    logout();
-                }
-            }, 2000);
-        } else {
-            showMessage('passwordMessage', data.error, 'error');
-        }
-    } catch (error) {
-        showMessage('passwordMessage', 'Error de conexión', 'error');
-    } finally {
-        changePasswordBtn.disabled = false;
-        changePasswordBtn.textContent = 'Cambiar Contraseña';
-    }
-}
-
-// Manejar envío de configuración de restricciones
-async function handleRestrictionsSubmit(e) {
-    e.preventDefault();
-    
-    const saveBtn = document.getElementById('saveRestrictionsBtn');
-    saveBtn.disabled = true;
-    saveBtn.textContent = 'Guardando...';
-    
-    try {
-        const formData = new FormData(document.getElementById('restrictionsForm'));
-        const config = {};
-        
-        // Convertir checkbox a string boolean
-        config.location_restriction_enabled = document.getElementById('locationRestrictionEnabled').checked ? 'true' : 'false';
-        config.device_restriction_enabled = document.getElementById('deviceRestrictionEnabled').checked ? 'true' : 'false';
-        config.admin_key_bypass_enabled = document.getElementById('adminKeyBypassEnabled').checked ? 'true' : 'false';
-        
-        // Otros campos
-        config.location_name = formData.get('location_name') || '';
-        config.location_latitude = formData.get('location_latitude') || '';
-        config.location_longitude = formData.get('location_longitude') || '';
-        config.location_radius_km = formData.get('location_radius_km') || '1';
-        
-        const response = await fetch('/api/admin/config', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${authToken}`
-            },
-            body: JSON.stringify(config)
-        });
-        
-        const data = await response.json();
-        
-        if (response.ok) {
-            showMessage('restrictionsMessage', 'Configuración guardada exitosamente', 'success');
-            systemConfig = config;
-        } else {
-            showMessage('restrictionsMessage', data.error, 'error');
-        }
-    } catch (error) {
-        showMessage('restrictionsMessage', 'Error de conexión', 'error');
-    } finally {
-        saveBtn.disabled = false;
-        saveBtn.textContent = 'Guardar Configuración';
-    }
-}
-
-function showAdminSection() {
-    document.getElementById('loginSection').classList.add('hidden');
-    document.getElementById('adminSection').classList.remove('hidden');
-}
-
-function logout() {
-    localStorage.removeItem('adminToken');
-    authToken = null;
-    document.getElementById('loginSection').classList.remove('hidden');
-    document.getElementById('adminSection').classList.add('hidden');
-    document.getElementById('username').value = '';
-    document.getElementById('password').value = '';
-}
-
-async function loadDashboard() {
-    await loadSystemConfig();
-    await loadStats();
-    await loadDetailedList();
-}
-
-// Cargar configuración del sistema
-async function loadSystemConfig() {
-    try {
-        const response = await fetch('/api/admin/config', {
-            headers: { 'Authorization': `Bearer ${authToken}` }
-        });
-        
-        if (response.ok) {
-            systemConfig = await response.json();
-            populateRestrictionsForm();
-        }
-    } catch (error) {
-        console.error('Error cargando configuración:', error);
-    }
-}
-
-// Poblar formulario de restricciones con datos actuales
-function populateRestrictionsForm() {
-    document.getElementById('locationRestrictionEnabled').checked = systemConfig.location_restriction_enabled === 'true';
-    document.getElementById('deviceRestrictionEnabled').checked = systemConfig.device_restriction_enabled === 'true';
-    document.getElementById('adminKeyBypassEnabled').checked = systemConfig.admin_key_bypass_enabled === 'true';
-    
-    document.getElementById('locationName').value = systemConfig.location_name || '';
-    document.getElementById('locationLatitude').value = systemConfig.location_latitude || '';
-    document.getElementById('locationLongitude').value = systemConfig.location_longitude || '';
-    document.getElementById('locationRadius').value = systemConfig.location_radius_km || '1';
-}
-
-// Obtener ubicación actual del administrador
-function getCurrentLocation() {
-    if (!navigator.geolocation) {
-        alert('La geolocalización no está disponible en este navegador');
-        return;
-    }
-    
-    navigator.geolocation.getCurrentPosition(
-        function(position) {
-            document.getElementById('locationLatitude').value = position.coords.latitude.toFixed(6);
-            document.getElementById('locationLongitude').value = position.coords.longitude.toFixed(6);
-            alert('Ubicación obtenida exitosamente');
-        },
-        function(error) {
-            alert('Error obteniendo ubicación: ' + error.message);
-        },
-        {
-            enableHighAccuracy: true,
-            timeout: 10000,
-            maximumAge: 300000
-        }
-    );
-}
-
-async function loadStats() {
-    try {
-        const response = await fetch('/api/admin/stats', {
-            headers: { 'Authorization': `Bearer ${authToken}` }
-        });
-        
-        if (response.ok) {
-            const stats = await response.json();
-            
-            document.getElementById('totalStudents').textContent = stats.totalStudents;
-            document.getElementById('presentRegistered').textContent = stats.presentRegistered;
-            const attendanceRate = stats.totalStudents > 0 ? 
-                ((stats.presentRegistered / stats.totalStudents) * 100).toFixed(1) : 0;
-            document.getElementById('attendanceRate').textContent = attendanceRate + '%';
-            document.getElementById('absent').textContent = stats.absent;
-            
-            const overviewContent = document.getElementById('overviewContent');
-            const overviewLoading = document.getElementById('overviewLoading');
-            
-            overviewLoading.style.display = 'none';
-            overviewContent.innerHTML = `
-                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-top: 20px;">
-                    <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
-                        <h3 style="color: #2ecc71; margin-bottom: 10px;">✅ Asistencia Total</h3>
-                        <p style="font-size: 24px; font-weight: bold;">${stats.totalPresent}</p>
-                        <p style="color: #666; font-size: 14px;">
-                            ${((stats.totalPresent / Math.max(stats.totalStudents, 1)) * 100).toFixed(1)}% del total
-                        </p>
-                    </div>
-                    <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
-                        <h3 style="color: #3498db; margin-bottom: 10px;">🪖 Personal Presente</h3>
-                        <p style="font-size: 24px; font-weight: bold;">${stats.presentRegistered}</p>
-                        <p style="color: #666; font-size: 14px;">
-                            ${stats.totalStudents > 0 ? ((stats.presentRegistered / stats.totalStudents) * 100).toFixed(1) : 0}% Asistencia
-                        </p>
-                    </div>
-                    <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
-                        <h3 style="color: #B22222; margin-bottom: 10px;">📊 Efectivo</h3>
-                        <p style="font-size: 24px; font-weight: bold;">${((stats.presentRegistered / Math.max(stats.totalStudents, 1)) * 100).toFixed(1)}%</p>
-                        <p style="color: #666; font-size: 14px;">Asistencia</p>
-                    </div>
-                    <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
-                        <h3 style="color: #9b59b6; margin-bottom: 10px;">🛡️ Restricciones</h3>
-                        <p style="font-size: 14px; font-weight: bold;">
-                            ${systemConfig.location_restriction_enabled === 'true' ? '📍 Ubicación' : ''}
-                            ${systemConfig.device_restriction_enabled === 'true' ? '📱 Dispositivo' : ''}
-                            ${systemConfig.location_restriction_enabled !== 'true' && systemConfig.device_restriction_enabled !== 'true' ? 'Ninguna' : ''}
-                        </p>
-                        <p style="color: #666; font-size: 12px;">Estado actual</p>
-                    </div>
-                </div>
-                <div style="margin-top: 20px; padding: 15px; background: #e9ecef; border-radius: 10px;">
-                    <p style="margin: 0;"><strong>Fecha:</strong> ${new Date(stats.date).toLocaleDateString('es-MX', { 
-                        year: 'numeric', 
-                        month: 'long', 
-                        day: 'numeric' 
-                    })}</p>
-                </div>
-            `;
-        } else {
-            throw new Error('Error al cargar estadísticas');
-        }
-    } catch (error) {
-        console.error('Error loading stats:', error);
-        if (error.message.includes('401') || error.message.includes('403')) {
-            logout();
-        }
-    }
-}
-
-async function loadDetailedList() {
-    try {
-        const response = await fetch('/api/admin/detailed-list', {
-            headers: { 'Authorization': `Bearer ${authToken}` }
-        });
-        
-        if (response.ok) {
-            const data = await response.json();
-            displayDetailedList(data);
-            document.getElementById('detailedLoading').style.display = 'none';
-        } else {
-            throw new Error('Error al cargar lista detallada');
-        }
-    } catch (error) {
-        console.error('Error loading detailed list:', error);
-        document.getElementById('detailedLoading').style.display = 'none';
-        if (error.message.includes('401') || error.message.includes('403')) {
-            logout();
-        }
-    }
-}
-
-function displayDetailedList(data) {
-    const content = document.getElementById('detailedContent');
-    
-    let html = '<div style="margin-bottom: 20px;">';
-    html += `<h3>Fecha: ${new Date(data.date).toLocaleDateString('es-MX', { year: 'numeric', month: 'long', day: 'numeric' })}</h3>`;
-    html += '</div>';
-    
-    if (data.presentRegistered.length > 0) {
-        html += '<h3 style="color: #2ecc71; margin: 20px 0 10px 0;">✅ Presentes (En Lista)</h3>';
-        html += createDetailedTable(data.presentRegistered);
-    }
-    
-    if (data.absent.length > 0) {
-        html += '<h3 style="color: #e74c3c; margin: 20px 0 10px 0;">❌ Faltistas</h3>';
-        html += createDetailedTable(data.absent);
-    }
-    
-    content.innerHTML = html;
-}
-
-function createDetailedTable(students) {
-    if (!students || students.length === 0) return '<p>No hay registros</p>';
-    
-    let html = '<div class="table-container"><table><thead><tr>';
-    html += '<th>Matrícula</th><th>Nombre</th><th>Grupo</th><th>Estado</th><th>Hora</th><th>Ubicación</th><th>Dispositivo</th>';
-    html += '</tr></thead><tbody>';
-    
-    students.forEach(student => {
-        const statusClass = student.status.includes('Presente') ? 'status-present' : 'status-absent';
-
-        const timeString = student.timestamp ? 
-            new Date(student.timestamp).toLocaleTimeString('es-MX', { 
-                hour: '2-digit', 
-                minute: '2-digit' 
-            }) : '-';
-        
-        html += `<tr>
-            <td>${student.matricula || '-'}</td>
-            <td>${decodeSpecialChars(student.nombre) || '-'}</td>
-            <td>${decodeSpecialChars(student.grupo || '-').toUpperCase()}</td>
-            <td><span class="status-badge ${statusClass}">${student.status}</span></td>
-            <td>${timeString}</td>
-            <td style="font-size: 12px;">${student.location || 'N/A'}</td>
-            <td style="font-size: 12px; font-family: monospace;">${student.device || 'N/A'}</td>
-        </tr>`;
-    });
-    
-    html += '</tbody></table></div>';
-    return html;
-}
-
-// Cargar dispositivos registrados
-async function loadDevices() {
-    try {
-        document.getElementById('devicesLoading').style.display = 'block';
-        
-        const response = await fetch('/api/admin/devices', {
-            headers: { 'Authorization': `Bearer ${authToken}` }
-        });
-        
-        if (response.ok) {
-            const devices = await response.json();
-            displayDevices(devices);
-        } else {
-            throw new Error('Error al cargar dispositivos');
-        }
-    } catch (error) {
-        console.error('Error loading devices:', error);
-        document.getElementById('devicesContent').innerHTML = '<p style="color: #e74c3c;">Error cargando dispositivos</p>';
-    } finally {
-        document.getElementById('devicesLoading').style.display = 'none';
-    }
-}
-
-function displayDevices(devices) {
-    const content = document.getElementById('devicesContent');
-    
-    if (devices.length === 0) {
-        content.innerHTML = '<p>No hay dispositivos registrados</p>';
-        return;
-    }
-
-    let html = '<div class="table-container"><table><thead><tr>';
-    html += '<th>Huella Digital</th><th>Matrícula</th><th>Primer Registro</th><th>Último Uso</th><th>Navegador</th>';
-    html += '</tr></thead><tbody>';
-    
-    devices.forEach(device => {
-        const firstRegistration = device.first_registration ? 
-            new Date(device.first_registration).toLocaleString('es-MX') : '-';
-        const lastUsed = device.last_used ? 
-            new Date(device.last_used).toLocaleString('es-MX') : '-';
-        
-        html += `<tr>
-            <td style="font-family: monospace; font-size: 12px;">${device.device_fingerprint}</td>
-            <td><strong>${device.matricula}</strong></td>
-            <td>${firstRegistration}</td>
-            <td>${lastUsed}</td>
-            <td style="font-size: 12px;">${device.user_agent || 'Desconocido'}</td>
-        </tr>`;
-    });
-    
-    html += '</tbody></table></div>';
-    content.innerHTML = html;
-}
-
-// Gestión de claves administrativas
-async function loadAdminKeys() {
-    try {
-        const response = await fetch('/api/admin/admin-keys', {
-            headers: { 'Authorization': `Bearer ${authToken}` }
-        });
-        
-        if (response.ok) {
-            const adminKeys = await response.json();
-            displayAdminKeys(adminKeys);
-        } else {
-            throw new Error('Error al cargar claves administrativas');
-        }
-    } catch (error) {
-        console.error('Error loading admin keys:', error);
-        document.getElementById('adminKeysList').innerHTML = '<p style="color: #e74c3c;">Error cargando claves administrativas</p>';
-    }
-}
-
-function displayAdminKeys(adminKeys) {
-    const content = document.getElementById('adminKeysList');
-    
-    if (adminKeys.length === 0) {
-        content.innerHTML = '<p>No hay claves administrativas configuradas</p>';
-        return;
-    }
-
-    let html = '';
-    adminKeys.forEach(key => {
-        const isActive = key.is_active === 'true';
-        const createdDate = new Date(key.created_at).toLocaleDateString('es-MX');
-        
-        html += `
-            <div class="admin-key-item ${isActive ? '' : 'inactive'}">
-                <div class="admin-key-info">
-                    <div style="font-weight: bold; font-family: monospace;">${key.key}</div>
-                    <div style="color: #666; font-size: 14px;">${key.description}</div>
-                    <div style="color: #999; font-size: 12px;">Creada: ${createdDate} | Estado: ${isActive ? '✅ Activa' : '❌ Inactiva'}</div>
-                </div>
-                <div class="admin-key-actions">
-                    ${isActive ? 
-                        `<button class="btn btn-danger btn-small" onclick="deactivateAdminKey('${key.key}')">Desactivar</button>` :
-                        '<span style="color: #999;">Inactiva</span>'
-                    }
-                </div>
-            </div>
-        `;
-    });
-    
-    content.innerHTML = html;
-}
-
-function showCreateKeyForm() {
-    document.getElementById('createKeyForm').classList.remove('hidden');
-    document.getElementById('newAdminKey').focus();
-}
-
-function hideCreateKeyForm() {
-    document.getElementById('createKeyForm').classList.add('hidden');
-    document.getElementById('newAdminKey').value = '';
-    document.getElementById('keyDescription').value = '';
-}
-
-async function createAdminKey() {
-    const key = document.getElementById('newAdminKey').value.trim().toUpperCase();
-    const description = document.getElementById('keyDescription').value.trim();
-    
-    if (!key || !description) {
-        alert('Por favor, completa todos los campos');
-        return;
-    }
-    
-    if (key.length < 4) {
-        alert('La clave debe tener al menos 4 caracteres');
-        return;
-    }
-    
-    try {
-        const response = await fetch('/api/admin/admin-keys', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${authToken}`
-            },
-            body: JSON.stringify({ key, description })
-        });
-        
-        const data = await response.json();
-        
-        if (response.ok) {
-            hideCreateKeyForm();
-            await loadAdminKeys();
-            alert('Clave administrativa creada exitosamente');
-        } else {
-            alert('Error: ' + data.error);
-        }
-    } catch (error) {
-        alert('Error de conexión');
-    }
-}
-
-function showTab(tabName) {
-    document.querySelectorAll('[id$="Tab"]').forEach(tab => {
-        tab.classList.add('hidden');
-    });
-    
-    document.querySelectorAll('.tab').forEach(tab => {
-        tab.classList.remove('active');
-    });
-    
-    document.getElementById(tabName + 'Tab').classList.remove('hidden');
-    event.target.classList.add('active');
-    
-    if (tabName === 'detailed') {
-        loadDetailedList();
-    } else if (tabName === 'settings') {
-        updateSystemInfo();
-    } else if (tabName === 'restrictions') {
-        loadSystemConfig();
-        loadAdminKeys();
-    } else if (tabName === 'devices') {
-        loadDevices();
-    }
-}
-
-async function previewCSV() {
-    const fileInput = document.getElementById('csvFile');
-    const file = fileInput.files[0];
-    
-    if (!file) return;
-    
-    const text = await file.text();
-    const lines = text.split('\n').filter(line => line.trim());
-    
-    if (lines.length === 0) {
-        showMessage('uploadMessage', 'El archivo está vacío', 'error');
-        return;
-    }
-    
-    const rows = lines.map(line => {
-        const columns = line.split(',').map(col => col.trim().replace(/"/g, ''));
-        return columns;
-    });
-    
-    const headers = rows[0];
-    const dataRows = rows.slice(1);
-    
-    const expectedHeaders = ['matricula', 'nombre', 'grupo'];
-    const hasRequiredHeaders = expectedHeaders.every(header => 
-        headers.some(h => h.toLowerCase() === header)
-    );
-    
-    if (!hasRequiredHeaders) {
-        showMessage('uploadMessage', 
-            'Headers obligatorios faltantes. Se requieren: matricula, nombre, grupo. Se encontraron: ' + headers.join(', '), 
-            'error');
-        return;
-    }
-    
-    currentStudents = dataRows.map(row => {
-        const student = {};
-        headers.forEach((header, index) => {
-            const cleanHeader = (header || '').toString().toLowerCase().trim();
-            const cleanValue = (row[index] || '').toString().trim();
-            student[cleanHeader] = cleanValue;
-        });
-        return student;
-    }).filter(student => 
-        student.matricula && 
-        student.matricula.trim() !== '' && 
-        student.nombre && 
-        student.nombre.trim() !== ''
-    );
-    
-    const preview = document.getElementById('csvPreview');
-    let html = '<div style="margin: 20px 0;">';
-    html += '<h3>Vista Previa (' + currentStudents.length + ' registros válidos)</h3>';
-    html += '<div class="table-container" style="max-height: 300px;">';
-    html += '<table><thead><tr><th>Matrícula</th><th>Nombre</th><th>Grupo</th></tr></thead><tbody>';
-
-    currentStudents.slice(0, 10).forEach(student => {
-        html += '<tr>';
-        html += '<td>' + student.matricula + '</td>';
-        html += '<td>' + decodeSpecialChars(student.nombre) + '</td>';
-        html += '<td>' + decodeSpecialChars(student.grupo || '-').toUpperCase() + '</td>';
-        html += '</tr>';
-    });
-    
-    html += '</tbody></table></div>';
-    if (currentStudents.length > 10) {
-        html += '<p style="color: #666; font-size: 14px;">Mostrando los primeros 10 de ' + currentStudents.length + ' registros</p>';
-    }
-    html += '</div>';
-    
-    preview.innerHTML = html;
-    document.getElementById('uploadBtn').disabled = false;
-}
-
-async function uploadStudents() {
-    if (currentStudents.length === 0) {
-        showMessage('uploadMessage', 'No hay estudiantes para subir', 'error');
-        return;
-    }
-    
-    const uploadBtn = document.getElementById('uploadBtn');
-    uploadBtn.disabled = true;
-    uploadBtn.textContent = 'Subiendo...';
-    
-    try {
-        const response = await fetch('/api/admin/upload-students', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer ' + authToken
-            },
-            body: JSON.stringify({ students: currentStudents })
-        });
-        
-        const data = await response.json();
-        
-        if (response.ok) {
-            showMessage('uploadMessage', data.message, 'success');
-            document.getElementById('csvFile').value = '';
-            document.getElementById('csvPreview').innerHTML = '';
-            currentStudents = [];
-            
-            await loadStats();
-            
-            // Mostrar advertencia sobre reinicio de restricciones
-            if (systemConfig.device_restriction_enabled === 'true') {
-                setTimeout(() => {
-                    showMessage('uploadMessage', '⚠️ Los dispositivos registrados han sido reiniciados debido a la nueva lista de personal', 'warning');
-                }, 3000);
-            }
-        } else {
-            showMessage('uploadMessage', data.error, 'error');
-        }
-    } catch (error) {
-        showMessage('uploadMessage', 'Error de conexión', 'error');
-    } finally {
-        uploadBtn.disabled = false;
-        uploadBtn.textContent = 'Subir Lista de Personal';
-    }
-}
-
-function updateSystemInfo() {
-    document.getElementById('currentUser').textContent = 'admin';
-    document.getElementById('sessionTime').textContent = new Date().toLocaleString('es-MX');
-    document.getElementById('lastUpdate').textContent = new Date().toLocaleString('es-MX');
-    
-    if (authToken) {
-        fetch('/api/admin/stats', {
-            headers: { 'Authorization': 'Bearer ' + authToken }
-        }).then(response => response.json())
-        .then(stats => {
-            document.getElementById('systemTotalStudents').textContent = stats.totalStudents;
-            document.getElementById('systemTodayRecords').textContent = stats.totalPresent;
-        }).catch(() => {
-            document.getElementById('systemTotalStudents').textContent = 'Error';
-            document.getElementById('systemTodayRecords').textContent = 'Error';
-        });
-    }
-}
-
-function showMessage(elementId, message, type) {
-    const element = document.getElementById(elementId);
-    element.innerHTML = decodeSpecialChars(message);
-    element.className = 'message ' + type;
-    element.style.display = 'block';
-    
-    setTimeout(() => {
-        element.style.display = 'none';
-    }, 5000);
-}
-
-// Función para decodificar caracteres especiales
-function decodeSpecialChars(text) {
-    if (!text || typeof text !== 'string') return text;
-    
-    return text.replace(/â/g, 'ñ')
-              .replace(/Ã¡/g, 'á')
-              .replace(/Ã©/g, 'é')
-              .replace(/Ã­/g, 'í')
-              .replace(/Ã³/g, 'ó')
-              .replace(/Ãº/g, 'ú')
-              .replace(/Ã/g, 'Á')
-              .replace(/Ã‰/g, 'É')
-              .replace(/Ã/g, 'Í')
-              .replace(/Ã"/g, 'Ó')
-              .replace(/Ãš/g, 'Ú')
-              .replace(/Ã±/g, 'ñ')
-              .replace(/Ã'/g, 'Ñ')
-              .replace(/Ã¼/g, 'ü')
-              .replace(/Ã/g, 'Ü');
-}
-
-// Actualización automática de estadísticas
-setInterval(() => {
-    if (authToken && !document.getElementById('adminSection').classList.contains('hidden')) {
-        loadStats();
-    }
-}, 30000);
-
-// Event listeners para habilitar/deshabilitar secciones según checkboxes
-document.addEventListener('DOMContentLoaded', function() {
-    // Manejar habilitación de configuración de ubicación
-    document.getElementById('locationRestrictionEnabled')?.addEventListener('change', function() {
-        const locationSettings = document.getElementById('locationSettings');
-        if (this.checked) {
-            locationSettings.style.opacity = '1';
-            locationSettings.querySelectorAll('input').forEach(input => input.disabled = false);
-        } else {
-            locationSettings.style.opacity = '0.5';
-            locationSettings.querySelectorAll('input').forEach(input => input.disabled = true);
-        }
-    });
-});
-</script>
 </body>
-</html> + data.error);
-        }
-    } catch (error) {
-        alert('Error de conexión');
-    }
-}
-
-async function deactivateAdminKey(key) {
-    if (!confirm(`¿Estás seguro de desactivar la clave "${key}"?`)) {
-        return;
-    }
-    
-    try {
-        const response = await fetch(`/api/admin/admin-keys/${key}`, {
-            method: 'DELETE',
-            headers: { 'Authorization': `Bearer ${authToken}` }
-        });
-        
-        const data = await response.json();
-        
-        if (response.ok) {
-            await loadAdminKeys();
-            alert('Clave administrativa desactivada exitosamente');
-        } else {
-            alert('Error: '<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Panel de Administración - Pase de Lista</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background-color: #f5f5f5;
-            color: #333;
-        }
-
-        .header {
-            background: linear-gradient(135deg, #e9a488 0%, #e27f66 100%);
-            color: white;
-            padding: 20px 0;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        }
-
-        .header .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 0 20px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .header h1 {
-            font-size: 24px;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .logout-btn {
-            background: rgba(255,255,255,0.2);
-            color: white;
-            border: none;
-            padding: 10px 20px;
-            border-radius: 20px;
-            cursor: pointer;
-            transition: background 0.3s ease;
-        }
-
-        .logout-btn:hover {
-            background: rgba(255,255,255,0.3);
-        }
-
-        .main-container {
-            max-width: 1200px;
-            margin: 30px auto;
-            padding: 0 20px;
-        }
-
-        .login-container {
-            max-width: 400px;
-            margin: 100px auto;
-            background: white;
-            padding: 40px;
-            border-radius: 20px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-        }
-
-        .card {
-            background: white;
-            border-radius: 15px;
-            padding: 25px;
-            margin-bottom: 25px;
-            box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-        }
-
-        .card h2 {
-            color: #333;
-            margin-bottom: 20px;
-            font-size: 22px;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .stats-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 20px;
-            margin-bottom: 30px;
-        }
-
-        .stat-card {
-            background: white;
-            padding: 25px;
-            border-radius: 15px;
-            box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-            text-align: center;
-            border-left: 5px solid;
-        }
-
-        .stat-card.total { border-left-color: #3498db; }
-        .stat-card.present { border-left-color: #2ecc71; }
-        .stat-card.not-in-list { border-left-color: #f39c12; }
-        .stat-card.absent { border-left-color: #e74c3c; }
-
-        .stat-number {
-            font-size: 36px;
-            font-weight: bold;
-            color: #333;
-            display: block;
-        }
-
-        .stat-label {
-            font-size: 14px;
-            color: #666;
-            margin-top: 5px;
-        }
-
-        .form-group {
-            margin-bottom: 20px;
-        }
-
-        .form-row {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 15px;
-        }
-
-        label {
-            display: block;
-            margin-bottom: 8px;
-            font-weight: 600;
-            color: #555;
-        }
-
-        input[type="text"], input[type="password"], input[type="file"], input[type="number"], select, input[type="checkbox"] {
-            width: 100%;
-            padding: 12px;
-            border: 2px solid #ddd;
-            border-radius: 8px;
-            font-size: 16px;
-            transition: border-color 0.3s ease;
-        }
-
-        input[type="checkbox"] {
-            width: auto;
-            margin-right: 8px;
-        }
-
-        .checkbox-group {
-            display: flex;
-            align-items: center;
-            margin-bottom: 15px;
-        }
-
-        input:focus, select:focus {
-            outline: none;
-            border-color: #667eea;
-        }
-
-        .btn {
-            background: linear-gradient(135deg, #ea8066, #a2554b);
-            color: white;
-            border: none;
-            padding: 12px 25px;
-            border-radius: 8px;
-            cursor: pointer;
-            font-size: 16px;
-            font-weight: 600;
-            transition: all 0.3s ease;
-        }
-
-        .btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
-        }
-
-        .btn:disabled {
-            opacity: 0.6;
-            cursor: not-allowed;
-            transform: none;
-        }
-
-        .btn-secondary {
-            background: #6c757d;
-        }
-
-        .btn-danger {
-            background: linear-gradient(135deg, #e74c3c, #c0392b);
-        }
-
-        .btn-success {
-            background: linear-gradient(135deg, #2ecc71, #27ae60);
-        }
-
-        .message {
-            padding: 12px;
-            border-radius: 8px;
-            margin: 15px 0;
-            display: none;
-        }
-
-        .message.success {
-            background-color: #d4edda;
-            color: #155724;
-            border: 1px solid #c3e6cb;
-        }
-
-        .message.error {
-            background-color: #f8d7da;
-            color: #721c24;
-            border: 1px solid #f5c6cb;
-        }
-
-        .message.warning {
-            background-color: #fff3cd;
-            color: #856404;
-            border: 1px solid #ffeaa7;
-        }
-
-        .table-container {
-            overflow-x: auto;
-            max-height: 600px;
-            overflow-y: auto;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-        }
-
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            background: white;
-        }
-
-        th, td {
-            padding: 12px;
-            text-align: left;
-            border-bottom: 1px solid #eee;
-        }
-
-        th {
-            background-color: #f8f9fa;
-            font-weight: 600;
-            color: #333;
-            position: sticky;
-            top: 0;
-            z-index: 10;
-        }
-
-        tbody tr:hover {
-            background-color: #f8f9fa;
-        }
-
-        .status-badge {
-            padding: 4px 12px;
-            border-radius: 15px;
-            font-size: 12px;
-            font-weight: 600;
-        }
-
-        .status-present { background: #d4edda; color: #155724; }
-        .status-registered { background: #d4edda; color: #155724; }
-        .status-absent { background: #f8d7da; color: #721c24; }
-
-        .loading {
-            text-align: center;
-            padding: 20px;
-            display: none;
-        }
-
-        .spinner {
-            border: 3px solid #f3f3f3;
-            border-top: 3px solid #eaa166;
-            border-radius: 50%;
-            width: 30px;
-            height: 30px;
-            animation: spin 1s linear infinite;
-            margin: 0 auto 10px;
-        }
-
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-
-        .hidden {
-            display: none;
-        }
-
-        .tabs {
-            display: flex;
-            margin-bottom: 20px;
-            border-bottom: 2px solid #eee;
-            overflow-x: auto;
-        }
-
-        .tab {
-            padding: 15px 25px;
-            cursor: pointer;
-            border-bottom: 3px solid transparent;
-            transition: all 0.3s ease;
-            font-weight: 600;
-            white-space: nowrap;
-        }
-
-        .tab.active {
-            border-bottom-color: #ea6f66;
-            color: #ea9066;
-        }
-
-        .tab:hover {
-            background-color: #f8f9fa;
-        }
-
-        .back-link {
-            color: white;
-            text-decoration: none;
-            opacity: 0.9;
-            transition: opacity 0.3s ease;
-        }
-
-        .back-link:hover {
-            opacity: 1;
-        }
-
-        .config-section {
-            background: #f8f9fa;
-            border-radius: 10px;
-            padding: 20px;
-            margin-bottom: 20px;
-        }
-
-        .config-section h3 {
-            color: #333;
-            margin-bottom: 15px;
-            font-size: 18px;
-        }
-
-        .restriction-card {
-            background: white;
-            border-radius: 8px;
-            padding: 20px;
-            margin-bottom: 15px;
-            border-left: 4px solid;
-        }
-
-        .restriction-card.location { border-left-color: #3498db; }
-        .restriction-card.device { border-left-color: #9b59b6; }
-        .restriction-card.admin-keys { border-left-color: #f39c12; }
-
-        .admin-key-item {
-            background: white;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            padding: 15px;
-            margin-bottom: 10px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .admin-key-item.inactive {
-            opacity: 0.6;
-            background: #f8f9fa;
-        }
-
-        .admin-key-info {
-            flex: 1;
-        }
-
-        .admin-key-actions {
-            display: flex;
-            gap: 10px;
-        }
-
-        .btn-small {
-            padding: 6px 12px;
-            font-size: 12px;
-        }
-
-        @media (max-width: 768px) {
-            .stats-grid {
-                grid-template-columns: repeat(2, 1fr);
-            }
-            
-            .header .container {
-                flex-direction: column;
-                gap: 15px;
-            }
-            
-            .tabs {
-                flex-direction: column;
-            }
-            
-            .tab {
-                text-align: center;
-            }
-
-            .form-row {
-                grid-template-columns: 1fr;
-            }
-        }
-
-        .info-box {
-            background: #e3f2fd;
-            border: 1px solid #bbdefb;
-            border-radius: 8px;
-            padding: 15px;
-            margin-bottom: 20px;
-            color: #1976d2;
-        }
-
-        .info-box h4 {
-            margin-bottom: 10px;
-            color: #1565c0;
-        }
-    </style>
-</head>
-<body>
-    <!-- Login Form -->
-    <div id="loginSection" class="login-container">
-        <div style="text-align: center; margin-bottom: 30px;">
-            <div style="width: 60px; height: 60px; background: linear-gradient(135deg, #667eea, #764ba2); border-radius: 50%; margin: 0 auto 15px; display: flex; align-items: center; justify-content: center; font-size: 24px; color: white;">👤</div>
-            <h2>Acceso Administrativo</h2>
-        </div>
-        
-        <form id="loginForm">
-            <div class="form-group">
-                <label for="username">Usuario:</label>
-                <input type="text" id="username" name="username" autocomplete="username" required>
-            </div>
-            
-            <div class="form-group">
-                <label for="password">Contraseña:</label>
-                <input type="password" id="password" name="password" autocomplete="current-password" required>
-            </div>
-            
-            <button type="submit" class="btn" style="width: 100%;">Iniciar Sesión</button>
-        </form>
-        
-        <div class="message" id="loginMessage"></div>
-        
-        <div style="text-align: center; margin-top: 20px;">
-            <a href="/" class="back-link" style="color: #6866ea;">← Volver al pase de lista</a>
-        </div>
-    </div>
-
-    <!-- Admin Dashboard -->
-    <div id="adminSection" class="hidden">
-        <div class="header">
-            <div class="container">
-                <h1>📊 Panel de Administración</h1>
-                <div>
-                    <a href="/" class="back-link">← Pase de Lista</a>
-                    <button class="logout-btn" onclick="logout()">Cerrar Sesión</button>
-                </div>
-            </div>
-        </div>
-
-        <div class="main-container">
-            <!-- Estadísticas -->
-            <div class="stats-grid">
-                <div class="stat-card total">
-                    <span class="stat-number" id="totalStudents">-</span>
-                    <span class="stat-label">Total Personal</span>
-                </div>
-                <div class="stat-card present">
-                    <span class="stat-number" id="presentRegistered">-</span>
-                    <span class="stat-label">Presentes (En Lista)</span>
-                </div>
-                <div class="stat-card present">
-                    <span class="stat-number" id="attendanceRate">-</span>
-                    <span class="stat-label">% Asistencia</span>
-                </div>
-                <div class="stat-card absent">
-                    <span class="stat-number" id="absent">-</span>
-                    <span class="stat-label">Faltistas</span>
-                </div>
-            </div>
-
-            <!-- Tabs -->
-            <div class="tabs">
-                <div class="tab active" onclick="showTab('overview')">📈 Resumen</div>
-                <div class="tab" onclick="showTab('detailed')">📋 Lista Detallada</div>
-                <div class="tab" onclick="showTab('restrictions')">🛡️ Restricciones</div>
-                <div class="tab" onclick="showTab('upload')">📤 Subir Lista</div>
-                <div class="tab" onclick="showTab('devices')">📱 Dispositivos</div>
-                <div class="tab" onclick="showTab('settings')">⚙️ Configuración</div>
-            </div>
-
-            <!-- Tab: Overview -->
-            <div id="overviewTab">
-                <div class="card">
-                    <h2>📅 Resumen del Día</h2>
-                    <div id="overviewContent">
-                        <div class="loading" id="overviewLoading">
-                            <div class="spinner"></div>
-                            <p>Cargando estadísticas...</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Tab: Detailed List -->
-            <div id="detailedTab" class="hidden">
-                <div class="card">
-                    <h2>📋 Lista Detallada de Asistencia</h2>
-                    <div class="loading" id="detailedLoading">
-                        <div class="spinner"></div>
-                        <p>Cargando lista detallada...</p>
-                    </div>
-                    <div id="detailedContent"></div>
-                </div>
-            </div>
-
-            <!-- Tab: Restrictions Configuration -->
-            <div id="restrictionsTab" class="hidden">
-                <div class="card">
-                    <h2>🛡️ Configuración de Restricciones</h2>
-                    
-                    <div class="info-box">
-                        <h4>ℹ️ Información sobre las Restricciones</h4>
-                        <p>Las restricciones permiten controlar dónde y cómo se puede registrar la asistencia. Los supervisores con claves administrativas pueden saltarse estas restricciones.</p>
-                    </div>
-
-                    <form id="restrictionsForm">
-                        <!-- Restricción de Ubicación -->
-                        <div class="restriction-card location">
-                            <div class="checkbox-group">
-                                <input type="checkbox" id="locationRestrictionEnabled" name="location_restriction_enabled">
-                                <label for="locationRestrictionEnabled"><strong>📍 Restricción por Ubicación</strong></label>
-                            </div>
-                            <p style="margin-bottom: 15px; color: #666;">Solo permite registrar asistencia dentro de un radio específico de una ubicación.</p>
-                            
-                            <div id="locationSettings">
-                                <div class="form-row">
-                                    <div class="form-group">
-                                        <label for="locationName">Nombre del Lugar:</label>
-                                        <input type="text" id="locationName" name="location_name" placeholder="Ej: Escuela Superior de Guerra">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="locationRadius">Radio (km):</label>
-                                        <input type="number" id="locationRadius" name="location_radius_km" min="0.1" max="10" step="0.1" placeholder="1.0">
-                                    </div>
-                                </div>
-                                <div class="form-row">
-                                    <div class="form-group">
-                                        <label for="locationLatitude">Latitud:</label>
-                                        <input type="text" id="locationLatitude" name="location_latitude" placeholder="19.4326">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="locationLongitude">Longitud:</label>
-                                        <input type="text" id="locationLongitude" name="location_longitude" placeholder="-99.1332">
-                                    </div>
-                                </div>
-                                <button type="button" class="btn btn-secondary btn-small" onclick="getCurrentLocation()">📍 Obtener mi Ubicación Actual</button>
-                            </div>
-                        </div>
-
-                        <!-- Restricción de Dispositivo -->
-                        <div class="restriction-card device">
-                            <div class="checkbox-group">
-                                <input type="checkbox" id="deviceRestrictionEnabled" name="device_restriction_enabled">
-                                <label for="deviceRestrictionEnabled"><strong>📱 Restricción por Dispositivo</strong></label>
-                            </div>
-                            <p style="color: #666;">Solo permite un registro por dispositivo/teléfono. Evita que múltiples personas usen el mismo dispositivo.</p>
-                        </div>
-
-                        <!-- Claves Administrativas -->
-                        <div class="restriction-card admin-keys">
-                            <div class="checkbox-group">
-                                <input type="checkbox" id="adminKeyBypassEnabled" name="admin_key_bypass_enabled">
-                                <label for="adminKeyBypassEnabled"><strong>🔑 Permitir Claves de Supervisor</strong></label>
-                            </div>
-                            <p style="color: #666;">Permite que supervisores
+</html>

--- a/public/js/admin-app.js
+++ b/public/js/admin-app.js
@@ -1,0 +1,44 @@
+// ================================
+// INICIALIZACIÓN DE LA INTERFAZ
+// ================================
+document.addEventListener('DOMContentLoaded', () => {
+    const loginForm = document.getElementById('loginForm');
+    const changePasswordForm = document.getElementById('changePasswordForm');
+    const restrictionsForm = document.getElementById('restrictionsForm');
+    const locationCheckbox = document.getElementById('locationRestrictionEnabled');
+    const tabs = Array.from(document.querySelectorAll('.tab'));
+
+    if (loginForm) {
+        loginForm.addEventListener('submit', handleLogin);
+    }
+
+    if (changePasswordForm) {
+        changePasswordForm.addEventListener('submit', handleChangePassword);
+    }
+
+    if (restrictionsForm) {
+        restrictionsForm.addEventListener('submit', handleRestrictionsSubmit);
+    }
+
+    if (locationCheckbox) {
+        locationCheckbox.addEventListener('change', handleLocationRestrictionChange);
+    }
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            showTab(tab.dataset.tab, tab);
+        });
+    });
+
+    handleLocationRestrictionChange();
+
+    if (authToken) {
+        showAdminSection();
+        const activeTab = document.querySelector('.tab.active') || tabs[0];
+        if (activeTab) {
+            showTab(activeTab.dataset.tab, activeTab);
+        }
+        loadDashboard();
+        updateSystemInfo();
+    }
+});

--- a/public/js/admin-data.js
+++ b/public/js/admin-data.js
@@ -1,0 +1,335 @@
+// ================================
+// FUNCIONES DE DATOS Y RENDERIZADO
+// ================================
+async function loadDashboard() {
+    await loadSystemConfig();
+    await loadStats();
+    await loadDetailedList();
+    ensureStatsPolling();
+}
+
+async function loadSystemConfig() {
+    if (!authToken) return;
+
+    try {
+        const response = await fetch('/api/admin/config', {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+
+        if (response.ok) {
+            systemConfig = await response.json();
+            populateRestrictionsForm();
+        } else if (response.status === 401 || response.status === 403) {
+            logout();
+        }
+    } catch (error) {
+        console.error('Error cargando configuración:', error);
+    }
+}
+
+async function loadStats() {
+    if (!authToken) return;
+
+    const overviewLoading = document.getElementById('overviewLoading');
+    if (overviewLoading) {
+        overviewLoading.style.display = 'block';
+    }
+
+    try {
+        const response = await fetch('/api/admin/stats', {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al cargar estadísticas');
+        }
+
+        const stats = await response.json();
+        const totalStudents = stats.totalStudents ?? 0;
+        const presentRegistered = stats.presentRegistered ?? 0;
+        const totalPresent = stats.totalPresent ?? presentRegistered;
+        const notInList = stats.notInList ?? 0;
+
+        document.getElementById('totalStudents').textContent = totalStudents;
+        document.getElementById('presentRegistered').textContent = presentRegistered;
+        const attendanceRate = totalStudents > 0
+            ? ((presentRegistered / totalStudents) * 100).toFixed(1)
+            : '0.0';
+        document.getElementById('attendanceRate').textContent = `${attendanceRate}%`;
+        document.getElementById('absent').textContent = stats.absent ?? '-';
+
+        const overviewContent = document.getElementById('overviewContent');
+        if (overviewContent) {
+            overviewContent.innerHTML = `
+                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-top: 20px;">
+                    <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
+                        <h3 style="color: #2ecc71; margin-bottom: 10px;">✅ Asistencia Total</h3>
+                        <p style="font-size: 24px; font-weight: bold;">${totalPresent}</p>
+                        <p style="color: #666; font-size: 14px;">${((totalPresent / Math.max(totalStudents || 1, 1)) * 100).toFixed(1)}% del total</p>
+                    </div>
+                    <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
+                        <h3 style="color: #f39c12; margin-bottom: 10px;">📍 Registros Fuera de Lista</h3>
+                        <p style="font-size: 24px; font-weight: bold;">${notInList}</p>
+                        <p style="color: #666; font-size: 14px;">Registros de personal no listado</p>
+                    </div>
+                    <div style="padding: 20px; background: #f8f9fa; border-radius: 10px;">
+                        <h3 style="color: #3498db; margin-bottom: 10px;">🛡️ Restricciones Activas</h3>
+                        <p style="font-size: 16px;">
+                            ${systemConfig.location_restriction_enabled === 'true' ? '📍 Ubicación ' : ''}
+                            ${systemConfig.device_restriction_enabled === 'true' ? '📱 Dispositivo ' : ''}
+                            ${systemConfig.admin_key_bypass_enabled === 'true' ? '🔑 Claves de supervisor ' : ''}
+                            ${systemConfig.location_restriction_enabled !== 'true' && systemConfig.device_restriction_enabled !== 'true' && systemConfig.admin_key_bypass_enabled !== 'true' ? 'Ninguna' : ''}
+                        </p>
+                        <p style="color: #666; font-size: 12px;">Estado actual</p>
+                    </div>
+                    <div style="margin-top: 20px; padding: 15px; background: #e9ecef; border-radius: 10px;">
+                        <p style="margin: 0;"><strong>Fecha:</strong> ${new Date(stats.date).toLocaleDateString('es-MX', {
+                            year: 'numeric',
+                            month: 'long',
+                            day: 'numeric'
+                        })}</p>
+                    </div>
+                </div>
+            `;
+        }
+    } catch (error) {
+        console.error('Error loading stats:', error);
+        if (String(error.message).includes('401') || String(error.message).includes('403')) {
+            logout();
+        }
+    } finally {
+        if (overviewLoading) {
+            overviewLoading.style.display = 'none';
+        }
+    }
+}
+
+async function loadDetailedList() {
+    if (!authToken) return;
+
+    const detailedLoading = document.getElementById('detailedLoading');
+    if (detailedLoading) {
+        detailedLoading.style.display = 'block';
+    }
+
+    try {
+        const response = await fetch('/api/admin/detailed-list', {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al cargar lista detallada');
+        }
+
+        const data = await response.json();
+        displayDetailedList(data);
+    } catch (error) {
+        console.error('Error loading detailed list:', error);
+        if (String(error.message).includes('401') || String(error.message).includes('403')) {
+            logout();
+        }
+    } finally {
+        if (detailedLoading) {
+            detailedLoading.style.display = 'none';
+        }
+    }
+}
+
+function displayDetailedList(data) {
+    const content = document.getElementById('detailedContent');
+    if (!content) return;
+
+    let html = '<div style="margin-bottom: 20px;">';
+    html += `<h3>Fecha: ${new Date(data.date).toLocaleDateString('es-MX', { year: 'numeric', month: 'long', day: 'numeric' })}</h3>`;
+    html += '</div>';
+
+    if (Array.isArray(data.presentRegistered) && data.presentRegistered.length > 0) {
+        html += '<h3 style="color: #2ecc71; margin: 20px 0 10px 0;">✅ Presentes (En Lista)</h3>';
+        html += createDetailedTable(data.presentRegistered);
+    }
+
+    if (Array.isArray(data.absent) && data.absent.length > 0) {
+        html += '<h3 style="color: #e74c3c; margin: 20px 0 10px 0;">❌ Faltistas</h3>';
+        html += createDetailedTable(data.absent);
+    }
+
+    if ((!Array.isArray(data.presentRegistered) || data.presentRegistered.length === 0) &&
+        (!Array.isArray(data.absent) || data.absent.length === 0)) {
+        html += '<p>No hay registros disponibles para la fecha seleccionada.</p>';
+    }
+
+    content.innerHTML = html;
+}
+
+function createDetailedTable(students) {
+    if (!students || students.length === 0) {
+        return '<p>No hay registros</p>';
+    }
+
+    let html = '<div class="table-container"><table><thead><tr>';
+    html += '<th>Matrícula</th><th>Nombre</th><th>Grupo</th><th>Estado</th><th>Hora</th><th>Ubicación</th><th>Dispositivo</th>';
+    html += '</tr></thead><tbody>';
+
+    students.forEach(student => {
+        const statusClass = student.status?.includes('Presente') ? 'status-present' : 'status-absent';
+        const timeString = student.timestamp
+            ? new Date(student.timestamp).toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' })
+            : '-';
+
+        html += `
+            <tr>
+                <td>${student.matricula || '-'}</td>
+                <td>${decodeSpecialChars(student.nombre || '-')}</td>
+                <td>${decodeSpecialChars((student.grupo || '-')).toUpperCase()}</td>
+                <td><span class="status-badge ${statusClass}">${student.status || '-'}</span></td>
+                <td>${timeString}</td>
+                <td style="font-size: 12px;">${student.location || 'N/A'}</td>
+                <td style="font-size: 12px; font-family: monospace;">${student.device || 'N/A'}</td>
+            </tr>
+        `;
+    });
+
+    html += '</tbody></table></div>';
+    return html;
+}
+
+async function loadDevices() {
+    if (!authToken) return;
+
+    const loading = document.getElementById('devicesLoading');
+    if (loading) {
+        loading.style.display = 'block';
+    }
+
+    try {
+        const response = await fetch('/api/admin/devices', {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al cargar dispositivos');
+        }
+
+        const devices = await response.json();
+        displayDevices(devices);
+    } catch (error) {
+        console.error('Error loading devices:', error);
+        document.getElementById('devicesContent').innerHTML = '<p style="color: #e74c3c;">Error cargando dispositivos</p>';
+        if (String(error.message).includes('401') || String(error.message).includes('403')) {
+            logout();
+        }
+    } finally {
+        if (loading) {
+            loading.style.display = 'none';
+        }
+    }
+}
+
+function displayDevices(devices) {
+    const content = document.getElementById('devicesContent');
+    if (!content) return;
+
+    if (!devices || devices.length === 0) {
+        content.innerHTML = '<p>No hay dispositivos registrados</p>';
+        return;
+    }
+
+    let html = '<div class="table-container"><table><thead><tr>';
+    html += '<th>Huella Digital</th><th>Matrícula</th><th>Primer Registro</th><th>Último Uso</th><th>Navegador</th>';
+    html += '</tr></thead><tbody>';
+
+    devices.forEach(device => {
+        const firstRegistration = device.first_registration ? new Date(device.first_registration).toLocaleString('es-MX') : '-';
+        const lastUsed = device.last_used ? new Date(device.last_used).toLocaleString('es-MX') : '-';
+
+        html += `
+            <tr>
+                <td style="font-family: monospace; font-size: 12px;">${device.device_fingerprint}</td>
+                <td><strong>${device.matricula}</strong></td>
+                <td>${firstRegistration}</td>
+                <td>${lastUsed}</td>
+                <td style="font-size: 12px;">${device.user_agent || 'Desconocido'}</td>
+            </tr>
+        `;
+    });
+
+    html += '</tbody></table></div>';
+    content.innerHTML = html;
+}
+
+async function loadAdminKeys() {
+    if (!authToken) return;
+
+    const container = document.getElementById('adminKeysList');
+    if (container) {
+        container.innerHTML = `
+            <div class="loading">
+                <div class="spinner"></div>
+                <p>Cargando claves administrativas...</p>
+            </div>
+        `;
+    }
+
+    try {
+        const response = await fetch('/api/admin/admin-keys', {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        });
+
+        if (!response.ok) {
+            throw new Error('Error al cargar claves administrativas');
+        }
+
+        const adminKeys = await response.json();
+        displayAdminKeys(adminKeys);
+    } catch (error) {
+        console.error('Error loading admin keys:', error);
+        if (container) {
+            container.innerHTML = '<p style="color: #e74c3c;">Error cargando claves administrativas</p>';
+        }
+        if (String(error.message).includes('401') || String(error.message).includes('403')) {
+            logout();
+        }
+    }
+}
+
+function displayAdminKeys(adminKeys) {
+    const content = document.getElementById('adminKeysList');
+    if (!content) return;
+
+    if (!adminKeys || adminKeys.length === 0) {
+        content.innerHTML = '<p>No hay claves administrativas configuradas</p>';
+        return;
+    }
+
+    let html = '';
+    adminKeys.forEach(key => {
+        const isActive = key.is_active === 'true';
+        const createdDate = key.created_at ? new Date(key.created_at).toLocaleDateString('es-MX') : '-';
+
+        html += `
+            <div class="admin-key-item ${isActive ? '' : 'inactive'}">
+                <div class="admin-key-info">
+                    <div style="font-weight: bold; font-family: monospace;">${key.key}</div>
+                    <div style="color: #666; font-size: 14px;">${decodeSpecialChars(key.description || '')}</div>
+                    <div style="color: #999; font-size: 12px;">Creada: ${createdDate} | Estado: ${isActive ? '✅ Activa' : '❌ Inactiva'}</div>
+                </div>
+                <div class="admin-key-actions">
+                    ${isActive
+                        ? `<button class="btn btn-danger btn-small" onclick="deactivateAdminKey('${key.key}')">Desactivar</button>`
+                        : '<span style="color: #999;">Inactiva</span>'}
+                </div>
+            </div>
+        `;
+    });
+
+    content.innerHTML = html;
+}
+
+// Exponer funciones necesarias globalmente
+window.loadDashboard = loadDashboard;
+window.loadSystemConfig = loadSystemConfig;
+window.loadStats = loadStats;
+window.loadDetailedList = loadDetailedList;
+window.loadDevices = loadDevices;
+window.loadAdminKeys = loadAdminKeys;
+window.displayAdminKeys = displayAdminKeys;

--- a/public/js/admin-handlers.js
+++ b/public/js/admin-handlers.js
@@ -32,6 +32,10 @@ async function handleLogin(e) {
             showAdminSection();
             await loadDashboard();
             updateSystemInfo();
+            const overviewTab = document.querySelector('.tab[data-tab="overview"]');
+            if (overviewTab) {
+                showTab('overview', overviewTab);
+            }
         } else {
             const errorMessage = data.error || data.message || 'Error de autenticación';
             showMessage('loginMessage', errorMessage, 'error');
@@ -135,10 +139,11 @@ async function handleRestrictionsSubmit(e) {
         });
         
         const data = await response.json();
-        
+
         if (response.ok) {
             showMessage('restrictionsMessage', 'Configuración guardada exitosamente', 'success');
             systemConfig = config;
+            populateRestrictionsForm();
         } else {
             showMessage('restrictionsMessage', data.error, 'error');
         }
@@ -352,18 +357,14 @@ async function uploadStudents() {
 }
 
 // ================================
-// EVENTOS DE RESTRICCIÓN DE UBICACIÓN
+// EXPONER FUNCIONES NECESARIAS
 // ================================
-
-function handleLocationRestrictionChange() {
-    const locationSettings = document.getElementById('locationSettings');
-    const checkbox = document.getElementById('locationRestrictionEnabled');
-    
-    if (checkbox.checked) {
-        locationSettings.style.opacity = '1';
-        locationSettings.querySelectorAll('input').forEach(input => input.disabled = false);
-    } else {
-        locationSettings.style.opacity = '0.5';
-        locationSettings.querySelectorAll('input').forEach(input => input.disabled = true);
-    }
-}
+window.handleLogin = handleLogin;
+window.handleChangePassword = handleChangePassword;
+window.handleRestrictionsSubmit = handleRestrictionsSubmit;
+window.showCreateKeyForm = showCreateKeyForm;
+window.hideCreateKeyForm = hideCreateKeyForm;
+window.createAdminKey = createAdminKey;
+window.deactivateAdminKey = deactivateAdminKey;
+window.previewCSV = previewCSV;
+window.uploadStudents = uploadStudents;

--- a/public/js/admin-utils.js
+++ b/public/js/admin-utils.js
@@ -1,0 +1,194 @@
+// ================================
+// VARIABLES GLOBALES
+// ================================
+let authToken = localStorage.getItem('adminToken');
+let currentStudents = [];
+let systemConfig = {};
+let statsIntervalId = null;
+
+// ================================
+// UTILIDADES GENERALES
+// ================================
+function showAdminSection() {
+    document.getElementById('loginSection').classList.add('hidden');
+    document.getElementById('adminSection').classList.remove('hidden');
+}
+
+function logout() {
+    localStorage.removeItem('adminToken');
+    authToken = null;
+    if (statsIntervalId) {
+        clearInterval(statsIntervalId);
+        statsIntervalId = null;
+    }
+    document.getElementById('loginSection').classList.remove('hidden');
+    document.getElementById('adminSection').classList.add('hidden');
+    document.getElementById('username').value = '';
+    document.getElementById('password').value = '';
+}
+
+function showTab(tabName, tabElement) {
+    document.querySelectorAll('[id$="Tab"]').forEach(tab => {
+        tab.classList.add('hidden');
+    });
+
+    document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
+
+    const target = document.getElementById(`${tabName}Tab`);
+    if (target) {
+        target.classList.remove('hidden');
+    }
+
+    if (tabElement) {
+        tabElement.classList.add('active');
+    } else {
+        const fallback = document.querySelector(`.tab[data-tab="${tabName}"]`);
+        fallback?.classList.add('active');
+    }
+
+    switch (tabName) {
+        case 'overview':
+            loadStats();
+            break;
+        case 'detailed':
+            loadDetailedList();
+            break;
+        case 'restrictions':
+            loadSystemConfig();
+            loadAdminKeys();
+            break;
+        case 'devices':
+            loadDevices();
+            break;
+        case 'settings':
+            updateSystemInfo();
+            break;
+        default:
+            break;
+    }
+}
+
+function updateSystemInfo() {
+    document.getElementById('currentUser').textContent = 'admin';
+    document.getElementById('sessionTime').textContent = new Date().toLocaleString('es-MX');
+    document.getElementById('lastUpdate').textContent = new Date().toLocaleString('es-MX');
+
+    if (authToken) {
+        fetch('/api/admin/stats', {
+            headers: { 'Authorization': `Bearer ${authToken}` }
+        })
+            .then(response => response.json())
+            .then(stats => {
+                document.getElementById('systemTotalStudents').textContent = stats.totalStudents ?? '-';
+                document.getElementById('systemTodayRecords').textContent = stats.totalPresent ?? '-';
+            })
+            .catch(() => {
+                document.getElementById('systemTotalStudents').textContent = 'Error';
+                document.getElementById('systemTodayRecords').textContent = 'Error';
+            });
+    }
+}
+
+function showMessage(elementId, message, type) {
+    const element = document.getElementById(elementId);
+    if (!element) return;
+
+    element.innerHTML = decodeSpecialChars(message);
+    element.className = `message ${type}`;
+    element.style.display = 'block';
+
+    setTimeout(() => {
+        element.style.display = 'none';
+    }, 5000);
+}
+
+function decodeSpecialChars(text) {
+    if (!text || typeof text !== 'string') {
+        return text;
+    }
+
+    try {
+        const bytes = new Uint8Array(Array.from(text, char => char.charCodeAt(0)));
+        const decoder = new TextDecoder('utf-8', { fatal: false });
+        return decoder.decode(bytes);
+    } catch (error) {
+        return text;
+    }
+}
+
+function populateRestrictionsForm() {
+    document.getElementById('locationRestrictionEnabled').checked = systemConfig.location_restriction_enabled === 'true';
+    document.getElementById('deviceRestrictionEnabled').checked = systemConfig.device_restriction_enabled === 'true';
+    document.getElementById('adminKeyBypassEnabled').checked = systemConfig.admin_key_bypass_enabled === 'true';
+
+    document.getElementById('locationName').value = systemConfig.location_name || '';
+    document.getElementById('locationLatitude').value = systemConfig.location_latitude || '';
+    document.getElementById('locationLongitude').value = systemConfig.location_longitude || '';
+    document.getElementById('locationRadius').value = systemConfig.location_radius_km || '1';
+
+    handleLocationRestrictionChange();
+}
+
+function handleLocationRestrictionChange() {
+    const locationSettings = document.getElementById('locationSettings');
+    const checkbox = document.getElementById('locationRestrictionEnabled');
+
+    if (!locationSettings || !checkbox) return;
+
+    const inputs = locationSettings.querySelectorAll('input');
+    const enabled = checkbox.checked;
+
+    locationSettings.style.opacity = enabled ? '1' : '0.5';
+    inputs.forEach(input => {
+        input.disabled = !enabled;
+    });
+}
+
+function getCurrentLocation() {
+    if (!navigator.geolocation) {
+        alert('La geolocalización no está disponible en este navegador');
+        return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+        position => {
+            document.getElementById('locationLatitude').value = position.coords.latitude.toFixed(6);
+            document.getElementById('locationLongitude').value = position.coords.longitude.toFixed(6);
+            alert('Ubicación obtenida exitosamente');
+        },
+        error => {
+            alert('Error obteniendo ubicación: ' + error.message);
+        },
+        {
+            enableHighAccuracy: true,
+            timeout: 10000,
+            maximumAge: 300000
+        }
+    );
+}
+
+function ensureStatsPolling() {
+    if (statsIntervalId) {
+        clearInterval(statsIntervalId);
+    }
+
+    statsIntervalId = setInterval(() => {
+        if (authToken && !document.getElementById('adminSection').classList.contains('hidden')) {
+            loadStats();
+        }
+    }, 30000);
+}
+
+// ================================
+// EXPONER FUNCIONES GLOBALES
+// ================================
+window.logout = logout;
+window.showTab = showTab;
+window.showAdminSection = showAdminSection;
+window.updateSystemInfo = updateSystemInfo;
+window.showMessage = showMessage;
+window.decodeSpecialChars = decodeSpecialChars;
+window.populateRestrictionsForm = populateRestrictionsForm;
+window.handleLocationRestrictionChange = handleLocationRestrictionChange;
+window.getCurrentLocation = getCurrentLocation;
+window.ensureStatsPolling = ensureStatsPolling;


### PR DESCRIPTION
## Summary
- rebuild `public/admin.html` to use the shared stylesheet and clean tab structure
- extract admin panel logic into dedicated utility, data, and handler scripts plus a bootstrapper
- improve tab, restriction, and CSV flows for better UX feedback and state handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f38625588323b0702a1e96301dda