### PR TITLE
Add SQLite-backed student storage and admin cleanup tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "better-sqlite3": "^12.4.1",
         "csv-parser": "^3.0.0",
         "csv-writer": "^1.6.0",
         "dotenv": "^16.4.5",
@@ -1657,6 +1658,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.10.tgz",
@@ -1673,6 +1694,20 @@
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.1.tgz",
+      "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1684,6 +1719,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -1776,6 +1831,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1934,6 +2013,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -2125,6 +2210,21 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
@@ -2138,6 +2238,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2174,6 +2283,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -2284,6 +2402,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -2587,6 +2714,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -2704,6 +2840,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2791,6 +2933,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2902,6 +3050,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -3059,6 +3213,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3139,6 +3313,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -4323,6 +4503,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4336,10 +4528,31 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -4356,6 +4569,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
+      "integrity": "sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-int64": {
@@ -4500,7 +4725,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4765,6 +4989,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4836,6 +5086,16 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4924,12 +5184,50 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -5270,6 +5568,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -5358,6 +5701,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -5461,6 +5813,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5520,6 +5900,18 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -5635,6 +6027,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -5726,7 +6124,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "better-sqlite3": "^12.4.1",
     "csv-parser": "^3.0.0",
     "csv-writer": "^1.6.0",
     "dotenv": "^16.4.5",

--- a/public/admin.html
+++ b/public/admin.html
@@ -244,6 +244,15 @@
                     </button>
 
                     <div class="message" id="uploadMessage"></div>
+
+                    <div class="danger-zone">
+                        <h3>🧹 Limpiar Base de Datos</h3>
+                        <p>Elimina todos los registros de personal almacenados en la base de datos y reinicia la lista de asistencia y dispositivos registrados.</p>
+                        <button class="btn btn-danger" onclick="clearStudentsDatabase()" id="clearStudentsBtn">
+                            Limpiar Base de Datos de Personal
+                        </button>
+                        <p class="danger-note">Esta acción no se puede deshacer. Asegúrate de contar con un respaldo antes de continuar.</p>
+                    </div>
                 </div>
             </div>
 

--- a/public/css/admin-styles.css
+++ b/public/css/admin-styles.css
@@ -253,6 +253,37 @@ input:focus, select:focus {
     border: 1px solid #ffeaa7;
 }
 
+.danger-zone {
+    margin-top: 30px;
+    padding: 20px;
+    border-radius: 12px;
+    border: 1px solid #f5c6cb;
+    background: #fff5f5;
+}
+
+.danger-zone h3 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    color: #c0392b;
+}
+
+.danger-zone p {
+    color: #7f8c8d;
+    font-size: 14px;
+    margin-bottom: 15px;
+}
+
+.danger-zone .btn-danger {
+    width: 100%;
+    margin-bottom: 10px;
+}
+
+.danger-note {
+    font-size: 12px;
+    color: #a94442;
+    margin: 0;
+}
+
 /* ================================
    TABLAS
    ================================ */

--- a/public/js/admin-handlers.js
+++ b/public/js/admin-handlers.js
@@ -356,6 +356,57 @@ async function uploadStudents() {
     }
 }
 
+async function clearStudentsDatabase() {
+    if (!authToken) {
+        showMessage('uploadMessage', 'Debes iniciar sesión para realizar esta acción', 'error');
+        return;
+    }
+
+    const confirmation = confirm('¿Estás seguro de que deseas eliminar todos los registros de personal? Esta acción no se puede deshacer.');
+    if (!confirmation) {
+        return;
+    }
+
+    const clearBtn = document.getElementById('clearStudentsBtn');
+    if (clearBtn) {
+        clearBtn.disabled = true;
+        clearBtn.textContent = 'Limpiando...';
+    }
+
+    try {
+        const response = await fetch('/api/admin/students/clear', {
+            method: 'DELETE',
+            headers: {
+                'Authorization': 'Bearer ' + authToken
+            }
+        });
+
+        const data = await response.json();
+
+        if (response.ok) {
+            showMessage('uploadMessage', data.message || 'Base de datos limpiada correctamente', 'success');
+            document.getElementById('csvFile').value = '';
+            document.getElementById('csvPreview').innerHTML = '';
+            currentStudents = [];
+
+            await Promise.all([
+                loadStats(),
+                loadDetailedList(),
+                loadDevices()
+            ]);
+        } else {
+            showMessage('uploadMessage', data.error || 'No se pudo limpiar la base de datos', 'error');
+        }
+    } catch (error) {
+        showMessage('uploadMessage', 'Error de conexión al limpiar la base de datos', 'error');
+    } finally {
+        if (clearBtn) {
+            clearBtn.disabled = false;
+            clearBtn.textContent = 'Limpiar Base de Datos de Personal';
+        }
+    }
+}
+
 // ================================
 // EXPONER FUNCIONES NECESARIAS
 // ================================
@@ -368,3 +419,4 @@ window.createAdminKey = createAdminKey;
 window.deactivateAdminKey = deactivateAdminKey;
 window.previewCSV = previewCSV;
 window.uploadStudents = uploadStudents;
+window.clearStudentsDatabase = clearStudentsDatabase;

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,8 +1,13 @@
+const path = require('path');
+
 try {
     require('dotenv').config();
 } catch (error) {
     console.warn('⚠️ dotenv no encontrado, usando configuración por defecto');
 }
+
+const DATA_DIR = process.env.DATA_DIR || 'data';
+const resolveDataPath = (...segments) => path.join(DATA_DIR, ...segments);
 
 const config = {
     // Configuración del servidor
@@ -14,14 +19,22 @@ const config = {
     JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || '8h',
     
     // Configuración de archivos
-    DATA_DIR: 'data',
+    DATA_DIR,
     FILES: {
-        STUDENTS: 'data/students.csv',
-        ATTENDANCE: 'data/attendance.csv',
-        ADMIN: 'data/admin.csv',
-        CONFIG: 'data/system_config.csv',
-        ADMIN_KEYS: 'data/admin_keys.csv',
-        DEVICES: 'data/devices.csv'
+        STUDENTS: resolveDataPath('students.csv'),
+        ATTENDANCE: resolveDataPath('attendance.csv'),
+        ADMIN: resolveDataPath('admin.csv'),
+        CONFIG: resolveDataPath('system_config.csv'),
+        ADMIN_KEYS: resolveDataPath('admin_keys.csv'),
+        DEVICES: resolveDataPath('devices.csv')
+    },
+
+    DATABASE: {
+        FILE: process.env.DATABASE_FILE || resolveDataPath('system.sqlite'),
+        BACKUP_DIR: resolveDataPath('backups'),
+        PRAGMA: {
+            foreign_keys: 'ON'
+        }
     },
 
     // Configuración de CSV

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -48,9 +48,9 @@ class AdminController {
      */
     static uploadStudents = asyncHandler(async (req, res) => {
         console.log('📤 Petición de subida de estudiantes');
-        
+
         const { students } = req.body;
-        
+
         const result = await StudentService.updateStudentsList(students);
 
         // Limpiar registros de asistencia al subir nueva lista
@@ -67,6 +67,24 @@ class AdminController {
                 errorsCount: result.errors.length,
                 errors: result.errors
             }
+        });
+    });
+
+    /**
+     * Limpiar todos los estudiantes de la base de datos
+     * DELETE /api/admin/students/clear
+     */
+    static clearStudents = asyncHandler(async (req, res) => {
+        console.log('🧹 Petición de limpieza de estudiantes');
+
+        const result = await StudentService.clearAllStudents();
+        await AttendanceService.clearAttendanceRecords();
+        await DeviceService.clearAllDevices();
+
+        res.status(200).json({
+            success: true,
+            message: 'Base de datos de estudiantes limpiada exitosamente. Registros relacionados fueron reiniciados.',
+            data: result
         });
     });
 

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -58,6 +58,9 @@ router.get('/realtime-metrics', AdminController.getRealtimeMetrics);
 // Subir nueva lista de estudiantes
 router.post('/upload-students', validateStudentsList, AdminController.uploadStudents);
 
+// Limpiar todos los estudiantes
+router.delete('/students/clear', AdminController.clearStudents);
+
 // Obtener estadísticas de estudiantes
 router.get('/students/stats', AdminController.getStudentStats);
 

--- a/src/services/databaseService.js
+++ b/src/services/databaseService.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const config = require('../config/server');
+
+class DatabaseService {
+    constructor() {
+        this.dbPath = config.DATABASE.FILE;
+        this.allowedTables = new Set(['students']);
+        this.ensureDirectories();
+        this.db = new Database(this.dbPath);
+        this.configure();
+        this.initializeTables();
+    }
+
+    ensureDirectories() {
+        const dataDir = path.dirname(this.dbPath);
+        fs.mkdirSync(dataDir, { recursive: true });
+
+        if (config.DATABASE.BACKUP_DIR) {
+            fs.mkdirSync(config.DATABASE.BACKUP_DIR, { recursive: true });
+        }
+    }
+
+    configure() {
+        const pragmas = {
+            journal_mode: 'WAL',
+            synchronous: 'NORMAL',
+            cache_size: -16000,
+            foreign_keys: 'ON',
+            ...config.DATABASE.PRAGMA
+        };
+
+        Object.entries(pragmas).forEach(([key, value]) => {
+            this.db.pragma(`${key} = ${value}`);
+        });
+    }
+
+    initializeTables() {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS students (
+                matricula TEXT PRIMARY KEY,
+                nombre TEXT NOT NULL,
+                grupo TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_students_grupo ON students (grupo);
+            CREATE INDEX IF NOT EXISTS idx_students_nombre ON students (nombre);
+        `);
+    }
+
+    prepare(sql) {
+        return this.db.prepare(sql);
+    }
+
+    run(sql, params = {}) {
+        return this.prepare(sql).run(params);
+    }
+
+    get(sql, params = {}) {
+        return this.prepare(sql).get(params);
+    }
+
+    all(sql, params = {}) {
+        return this.prepare(sql).all(params);
+    }
+
+    transaction(fn) {
+        return this.db.transaction(fn);
+    }
+
+    backupDatabase(label = 'backup') {
+        if (!config.DATABASE.BACKUP_DIR) {
+            return null;
+        }
+
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const sanitizedLabel = label.replace(/[^a-zA-Z0-9_-]/g, '_');
+        const backupFile = path.join(
+            config.DATABASE.BACKUP_DIR,
+            `${sanitizedLabel}-${timestamp}.sqlite`
+        );
+
+        fs.copyFileSync(this.dbPath, backupFile);
+        return backupFile;
+    }
+
+    clearTable(tableName) {
+        if (!this.allowedTables.has(tableName)) {
+            throw new Error(`Operación no permitida en la tabla ${tableName}`);
+        }
+
+        return this.run(`DELETE FROM ${tableName}`);
+    }
+}
+
+module.exports = new DatabaseService();


### PR DESCRIPTION
## Summary
- introduce a reusable database service and migrate the student service to use a SQLite data store instead of CSV files
- update system initialization and configuration to recognize the new database, add supporting dependency wiring, and provide student stats from the database
- expose an authenticated endpoint and admin UI controls to clear student records while resetting attendance and device data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3fe16da50832381af6b3bb069355a