### PR TITLE
Improve encoding support for Spanish CSV imports

### DIFF
--- a/__tests__/encoding.test.js
+++ b/__tests__/encoding.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+const { decodePotentiallyMisencodedText, hasEncodingArtifacts } = require('../src/utils/encoding');
+const Student = require('../src/models/Student');
+const CSVService = require('../src/services/csvService');
+
+describe('encoding utilities', () => {
+    test('detects encoding artifacts', () => {
+        expect(hasEncodingArtifacts('Jos\uFFFD')).toBe(true);
+        expect(hasEncodingArtifacts('JosÃ©')).toBe(true);
+        expect(hasEncodingArtifacts('José')).toBe(false);
+    });
+
+    test('decodes misencoded text back to UTF-8', () => {
+        const original = 'José López';
+        const misencoded = Buffer.from(original, 'utf8').toString('latin1');
+
+        expect(misencoded).not.toBe(original);
+        const decoded = decodePotentiallyMisencodedText(misencoded);
+        expect(decoded).toBe(original);
+    });
+});
+
+describe('Student encoding normalization', () => {
+    test('normalizes and decodes misencoded names and groups', () => {
+        const data = {
+            matricula: 'abc123',
+            nombre: Buffer.from('María-José', 'utf8').toString('latin1'),
+            grupo: Buffer.from('Información', 'utf8').toString('latin1')
+        };
+
+        const student = new Student(data);
+
+        expect(student.matricula).toBe('ABC123');
+        expect(student.nombre).toBe('María-José');
+        expect(student.grupo).toBe('INFORMACIÓN');
+    });
+});
+
+describe('CSVService encoding handling', () => {
+    const tempDir = path.join(__dirname, 'tmp');
+    const tempFile = path.join(tempDir, 'encoding.csv');
+
+    beforeAll(async () => {
+        await fs.promises.mkdir(tempDir, { recursive: true });
+    });
+
+    afterAll(async () => {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+    });
+
+    test('reads CSV files containing misencoded values', async () => {
+        const csvContent = 'matricula,nombre,grupo\n'
+            + '001,José,Infantería\n'
+            + '002,Ana María,Informática\n';
+
+        const latin1Buffer = Buffer.from(csvContent, 'latin1');
+        await fs.promises.writeFile(tempFile, latin1Buffer);
+
+        const rows = await CSVService.readCSV(tempFile);
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0].nombre).toBe('José');
+        expect(rows[0].grupo).toBe('Infantería');
+        expect(rows[1].nombre).toBe('Ana María');
+        expect(rows[1].grupo).toBe('Informática');
+    });
+});

--- a/src/models/Student.js
+++ b/src/models/Student.js
@@ -1,3 +1,5 @@
+const { decodePotentiallyMisencodedText } = require('../utils/encoding');
+
 /**
  * Modelo para representar un estudiante/personal militar
  */
@@ -23,7 +25,9 @@ class Student {
      */
     normalizeName(nombre) {
         if (!nombre) return '';
-        return nombre.toString().trim();
+        const stringValue = nombre.toString();
+        const decoded = decodePotentiallyMisencodedText(stringValue);
+        return decoded.trim();
     }
 
     /**
@@ -31,7 +35,9 @@ class Student {
      */
     normalizeGroup(grupo) {
         if (!grupo) return '';
-        return grupo.toString().trim().toUpperCase();
+        const stringValue = grupo.toString();
+        const decoded = decodePotentiallyMisencodedText(stringValue);
+        return decoded.trim().toUpperCase();
     }
 
     /**

--- a/src/utils/encoding.js
+++ b/src/utils/encoding.js
@@ -1,0 +1,78 @@
+const { TextDecoder } = require('util');
+
+const ENCODING_ARTIFACT_REGEX = /Ã.|Â./;
+const ENCODINGS_TO_TRY = ['utf-8', 'windows-1252', 'iso-8859-1', 'latin1'];
+
+function hasEncodingArtifacts(text) {
+    if (!text || typeof text !== 'string') {
+        return false;
+    }
+
+    return text.includes('\uFFFD') || ENCODING_ARTIFACT_REGEX.test(text);
+}
+
+function decodeText(bytes, encoding) {
+    try {
+        const decoder = new TextDecoder(encoding, { fatal: false });
+        return decoder.decode(bytes);
+    } catch (error) {
+        return null;
+    }
+}
+
+function decodePotentiallyMisencodedText(value) {
+    if (!value || typeof value !== 'string') {
+        return value;
+    }
+
+    if (value.includes('\uFFFD')) {
+        return value;
+    }
+
+    if (!hasEncodingArtifacts(value)) {
+        return value;
+    }
+
+    const bytes = Uint8Array.from(Buffer.from(value, 'binary'));
+
+    for (const encoding of ENCODINGS_TO_TRY) {
+        const decoded = decodeText(bytes, encoding);
+        if (decoded && !hasEncodingArtifacts(decoded)) {
+            return decoded;
+        }
+    }
+
+    return value;
+}
+
+function decodeBufferToText(buffer) {
+    if (!buffer) {
+        return '';
+    }
+
+    let bytes;
+
+    if (buffer instanceof Uint8Array) {
+        bytes = buffer;
+    } else if (Buffer.isBuffer(buffer)) {
+        bytes = new Uint8Array(buffer);
+    } else {
+        bytes = Uint8Array.from(buffer);
+    }
+
+    for (const encoding of ENCODINGS_TO_TRY) {
+        const decoded = decodeText(bytes, encoding);
+        if (decoded && !hasEncodingArtifacts(decoded)) {
+            return decoded;
+        }
+    }
+
+    const fallback = decodeText(bytes, 'utf-8');
+    return fallback || '';
+}
+
+module.exports = {
+    hasEncodingArtifacts,
+    decodePotentiallyMisencodedText,
+    decodeBufferToText
+};


### PR DESCRIPTION
## Summary
- add shared encoding utilities to decode Latin characters reliably
- ensure student normalization and CSV parsing fix common mojibake artifacts
- cover encoding flows with Jest tests for utilities, students, and CSV reads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4353cdd5c8323ad01e364a3cc427c