### PR TITLE
docs: add postgres configuration guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# URL de conexión a PostgreSQL
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/pase_lista
+
+# Habilitar SSL (true/false)
+DATABASE_SSL=false
+
+# Tamaño máximo del pool de conexiones
+DATABASE_MAX_POOL_SIZE=10
+
+# Tiempo máximo que una conexión puede estar inactiva (ms)
+DATABASE_IDLE_TIMEOUT_MS=30000
+
+# Tiempo máximo de espera para conectar (ms)
+DATABASE_CONNECTION_TIMEOUT_MS=2000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Sistema Pase Lista v2
+
+## Requisitos previos
+- Node.js 18 o superior
+- PostgreSQL 13 o superior
+
+## Instalación
+1. Instala dependencias:
+   ```bash
+   npm install
+   ```
+2. Copia el archivo de ejemplo de variables de entorno:
+   ```bash
+   cp .env.example .env
+   ```
+3. Ajusta las variables del archivo `.env` según tu entorno.
+
+## Configuración de la base de datos
+El sistema usa PostgreSQL mediante la variable `DATABASE_URL`. Su valor por defecto es:
+
+```
+postgresql://postgres:postgres@localhost:5432/pase_lista
+```
+
+Si tu usuario `postgres` tiene una contraseña diferente o utilizas otro usuario, debes actualizar `DATABASE_URL` en tu `.env`:
+
+```
+DATABASE_URL=postgresql://USUARIO:CONTRASENA@HOST:PUERTO/NOMBRE_BASE
+```
+
+Asegúrate de que:
+- El servidor de PostgreSQL esté en ejecución.
+- El usuario y contraseña sean válidos.
+- La base de datos `pase_lista` exista (`createdb pase_lista`).
+
+## Ejecución
+Inicia el servidor con:
+```bash
+npm start
+```
+
+Si aparece `Error: la autenticación password falló para el usuario "postgres"`, significa que las credenciales de `DATABASE_URL` no coinciden con las configuradas en PostgreSQL. Corrige la contraseña o crea un usuario con esa contraseña.


### PR DESCRIPTION
## Summary
- document the PostgreSQL configuration required to run the project locally
- add an example .env file with the expected database connection variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52f9ddff083238bd750ba16d46347