### PR TITLE
Mejorar manejo de errores y sincronización al subir personal

### DIFF
--- a/public/js/admin-utils.js
+++ b/public/js/admin-utils.js
@@ -87,6 +87,56 @@ function cerrarSesion() {
     }
 }
 
+async function obtenerRespuestaSegura(response) {
+    let data = null;
+    let rawText = '';
+
+    try {
+        data = await response.clone().json();
+    } catch (error) {
+        data = null;
+    }
+
+    try {
+        rawText = await response.text();
+    } catch (error) {
+        rawText = '';
+    }
+
+    return { data, rawText };
+}
+
+function obtenerMensajeRespuesta(payload, fallback, rawText = '') {
+    if (payload && typeof payload === 'object') {
+        const candidatosDirectos = [payload.message, payload.error, payload.descripcion, payload.detail];
+        for (const candidato of candidatosDirectos) {
+            if (typeof candidato === 'string' && candidato.trim().length > 0) {
+                return candidato.trim();
+            }
+        }
+
+        const colecciones = [payload.errors, payload.details];
+        for (const coleccion of colecciones) {
+            if (Array.isArray(coleccion) && coleccion.length > 0) {
+                const primero = coleccion[0];
+                if (typeof primero === 'string' && primero.trim().length > 0) {
+                    return primero.trim();
+                }
+            }
+        }
+    }
+
+    if (typeof payload === 'string' && payload.trim().length > 0) {
+        return payload.trim();
+    }
+
+    if (typeof rawText === 'string' && rawText.trim().length > 0) {
+        return rawText.trim();
+    }
+
+    return fallback;
+}
+
 async function mostrarSeccionTablero(sectionId, triggerElement = null) {
     const techMessage = document.getElementById('techAccessMessage');
     const managementSection = document.getElementById('managementSection');


### PR DESCRIPTION
## Summary
- add safe response parsing helpers for admin panel fetch calls
- update personal upload and cleanup flows to surface backend messages and avoid false connection errors
- improve logging and warnings when follow-up dashboard refresh calls fail
- refresh dashboard statistics, detailed list, and devices after uploading or clearing staff so the results panel stays in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eee86a400083239951a060e28e3f91